### PR TITLE
Add OAuth 2.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ scripts/tunnel.sh ngrok /path/to/repo
 scripts/tunnel.sh devtunnel /path/to/repo
 ```
 
-For clients that support custom headers, use bearer-token auth with `Authorization: Bearer <token>`. Clients that cannot send custom bearer headers should use anonymous `read-only` mode only for local/testing tunnels, or be placed behind an external auth proxy for production use.
+For clients that support custom headers, use bearer-token auth with `Authorization: Bearer <token>`. For MCP clients that speak OAuth 2.1 Authorization Code + PKCE, use `CODING_TOOLS_MCP_AUTH_MODE=oauth` with `scripts/tunnel.sh` (or `scripts/install.sh --auth-mode oauth`); the only env var you need to set is `CODING_TOOLS_MCP_SERVER_URL` (which must match the tunnel's stable public URL), and the script prints generated `CLIENT_ID`/`CLIENT_SECRET`/`PASSWORD` values on startup. Clients that cannot send custom bearer headers and do not speak OAuth should use anonymous `read-only` mode only for local/testing tunnels, or be placed behind an external auth proxy for production use.
 
 See [docs/remote-mcp.md](docs/remote-mcp.md) for the exact modes and security notes.
 

--- a/coding_tools_mcp/server.py
+++ b/coding_tools_mcp/server.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 import base64
 import ctypes
+import hashlib
+import html
 import difflib
 import fnmatch
 import http.server
@@ -24,6 +26,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
+
+import jwt
 
 from . import __version__
 
@@ -149,6 +153,45 @@ ENV_FLAG_OPTIONS = {
 NETWORK_LITERAL_COMMANDS = {"echo", "printf", "grep", "egrep", "fgrep", "rg", "cat", "head", "tail", "wc"}
 INLINE_SCRIPT_PERMISSION = "inline_script"
 ENV_PREFIX = "CODING_TOOLS_MCP"
+
+OAUTH_CODE_TTL_SECONDS = 300
+OAUTH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30
+OAUTH_MAX_BODY_BYTES = 8_192
+
+
+@dataclass(frozen=True)
+class OAuthConfig:
+    client_id: str
+    client_secret: str
+    password: str
+    server_url: str
+    token_secret: bytes
+    token_ttl: int = OAUTH_TOKEN_TTL_SECONDS
+
+
+def _verify_pkce(code_verifier: str, code_challenge: str) -> bool:
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    expected = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return secrets.compare_digest(expected, code_challenge)
+
+
+def _create_oauth_token(cfg: OAuthConfig) -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {"iss": cfg.server_url, "aud": cfg.server_url, "iat": now, "exp": now + cfg.token_ttl, "scope": "mcp"},
+        cfg.token_secret,
+        algorithm="HS256",
+    )
+
+
+def _validate_oauth_token(token: str, cfg: OAuthConfig) -> bool:
+    try:
+        jwt.decode(token, cfg.token_secret, algorithms=["HS256"], audience=cfg.server_url, issuer=cfg.server_url)
+        return True
+    except jwt.PyJWTError:
+        return False
+
+
 TOOL_PROFILE_CHOICES = ("full", "read-only", "compat-readonly-all")
 FULL_TOOL_NAMES = (
     "server_info",
@@ -824,6 +867,7 @@ class Runtime:
         dangerously_skip_all_permissions: bool = False,
         tool_profile: str = "full",
         auth_token: str | None = None,
+        oauth_config: OAuthConfig | None = None,
     ) -> None:
         self.workspace = Workspace(workspace)
         self.enable_view_image = enable_view_image
@@ -837,6 +881,9 @@ class Runtime:
             )
         self.tool_profile = tool_profile
         self.auth_token = auth_token or None
+        self.oauth_config = oauth_config
+        self._pending_codes: dict[str, dict[str, Any]] = {}
+        self._pending_codes_lock = threading.Lock()
         self.default_cwd = self.workspace.root
         self.sessions: dict[str, ExecSession] = {}
         self.sessions_lock = threading.Lock()
@@ -865,7 +912,10 @@ class Runtime:
         return [name for name in names if self.enable_view_image or name != "view_image"]
 
     def auth_enabled(self) -> bool:
-        return self.auth_token is not None
+        return self.auth_token is not None or self.oauth_config is not None
+
+    def oauth_enabled(self) -> bool:
+        return self.oauth_config is not None
 
     def default_cwd_display(self) -> str:
         return normalize_rel_display(self.default_cwd, self.workspace.root)
@@ -3755,6 +3805,23 @@ def input_schemas() -> dict[str, dict[str, Any]]:
     }
 
 
+def _server_card_auth(runtime: Runtime) -> dict[str, Any]:
+    if runtime.oauth_enabled():
+        cfg = runtime.oauth_config
+        assert cfg is not None
+        base = cfg.server_url.rstrip("/")
+        return {
+            "type": "oauth2",
+            "scheme": "Bearer",
+            "header": "Authorization",
+            "authorizationUrl": f"{base}/oauth/authorize",
+            "tokenUrl": f"{base}/oauth/token",
+        }
+    if runtime.auth_token is not None:
+        return {"type": "bearer", "scheme": "Bearer", "header": "Authorization"}
+    return {"type": "none", "scheme": None, "header": None}
+
+
 def server_card_payload(runtime: Runtime) -> dict[str, Any]:
     names = runtime.exposed_tool_names()
     annotations = {name: tool_definition(name, tool_profile=runtime.tool_profile)["annotations"] for name in names}
@@ -3772,11 +3839,7 @@ def server_card_payload(runtime: Runtime) -> dict[str, Any]:
             "endpoint": "/mcp",
             "methods": ["GET", "HEAD", "POST", "OPTIONS"],
         },
-        "auth": {
-            "type": "bearer" if runtime.auth_enabled() else "none",
-            "scheme": "Bearer" if runtime.auth_enabled() else None,
-            "header": "Authorization" if runtime.auth_enabled() else None,
-        },
+        "auth": _server_card_auth(runtime),
         "toolProfile": runtime.tool_profile,
         "tools": {
             "count": len(names),
@@ -3814,7 +3877,15 @@ class MCPHandler(http.server.BaseHTTPRequestHandler):
 
     def do_OPTIONS(self) -> None:
         request_path = self.path.split("?", 1)[0]
-        if posixpath.normpath(request_path) not in {"/mcp", "/.well-known/mcp.json", "/.well-known/mcp/server-card.json"}:
+        if posixpath.normpath(request_path) not in {
+            "/mcp",
+            "/.well-known/mcp.json",
+            "/.well-known/mcp/server-card.json",
+            "/.well-known/oauth-authorization-server",
+            "/.well-known/oauth-protected-resource",
+            "/oauth/authorize",
+            "/oauth/token",
+        }:
             self.send_json({"error": "Unknown endpoint"}, status=404)
             return
         origin = self.headers.get("Origin")
@@ -3829,6 +3900,15 @@ class MCPHandler(http.server.BaseHTTPRequestHandler):
     def handle_metadata_request(self, *, head_only: bool) -> None:
         request_path = self.path.split("?", 1)[0]
         normalized = posixpath.normpath(request_path)
+        if normalized == "/.well-known/oauth-authorization-server":
+            self.handle_oauth_as_metadata(head_only=head_only)
+            return
+        if normalized == "/.well-known/oauth-protected-resource":
+            self.handle_oauth_resource_metadata(head_only=head_only)
+            return
+        if normalized == "/oauth/authorize" and not head_only:
+            self.handle_oauth_authorize_get()
+            return
         if normalized == "/mcp":
             origin = self.headers.get("Origin")
             if origin and not is_allowed_origin(origin, auth_enabled=self.runtime.auth_enabled()):
@@ -3846,7 +3926,14 @@ class MCPHandler(http.server.BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:
         request_path = self.path.split("?", 1)[0]
-        if posixpath.normpath(request_path) != "/mcp":
+        normalized = posixpath.normpath(request_path)
+        if normalized == "/oauth/authorize":
+            self.handle_oauth_authorize_post()
+            return
+        if normalized == "/oauth/token":
+            self.handle_oauth_token()
+            return
+        if normalized != "/mcp":
             self.send_json({"jsonrpc": "2.0", "id": None, "error": {"code": -32601, "message": "Unknown endpoint"}}, status=404)
             return
         origin = self.headers.get("Origin")
@@ -4049,17 +4136,282 @@ class MCPHandler(http.server.BaseHTTPRequestHandler):
     def is_authorized(self) -> bool:
         if not self.runtime.auth_enabled():
             return True
-        header = self.headers.get("Authorization", "")
-        expected = f"Bearer {self.runtime.auth_token}"
-        return secrets.compare_digest(header.strip(), expected)
+        header = self.headers.get("Authorization", "").strip()
+        if self.runtime.auth_token is not None:
+            if secrets.compare_digest(header, f"Bearer {self.runtime.auth_token}"):
+                return True
+        if self.runtime.oauth_config is not None and header.startswith("Bearer "):
+            token = header[len("Bearer "):]
+            if _validate_oauth_token(token, self.runtime.oauth_config):
+                return True
+        return False
 
     def send_unauthorized(self, *, head_only: bool = False) -> None:
+        if self.runtime.oauth_config is not None:
+            base = self.runtime.oauth_config.server_url.rstrip("/")
+            www_auth = f'Bearer realm="coding-tools-mcp", resource_metadata="{base}/.well-known/oauth-protected-resource"'
+        else:
+            www_auth = 'Bearer realm="coding-tools-mcp"'
         self.send_json(
             {"jsonrpc": "2.0", "id": None, "error": {"code": -32000, "message": "Unauthorized"}},
             status=401,
-            extra_headers={"WWW-Authenticate": 'Bearer realm="coding-tools-mcp"'},
+            extra_headers={"WWW-Authenticate": www_auth},
             head_only=head_only,
         )
+
+    def handle_oauth_as_metadata(self, *, head_only: bool = False) -> None:
+        cfg = self.runtime.oauth_config
+        if cfg is None:
+            self.send_json({"error": "OAuth not configured"}, status=404, head_only=head_only)
+            return
+        base = cfg.server_url.rstrip("/")
+        self.send_json(
+            {
+                "issuer": base,
+                "authorization_endpoint": f"{base}/oauth/authorize",
+                "token_endpoint": f"{base}/oauth/token",
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code"],
+                "code_challenge_methods_supported": ["S256"],
+                "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+            },
+            head_only=head_only,
+        )
+
+    def handle_oauth_resource_metadata(self, *, head_only: bool = False) -> None:
+        cfg = self.runtime.oauth_config
+        if cfg is None:
+            self.send_json({"error": "OAuth not configured"}, status=404, head_only=head_only)
+            return
+        base = cfg.server_url.rstrip("/")
+        self.send_json(
+            {"resource": base, "authorization_servers": [base], "bearer_methods_supported": ["header"]},
+            head_only=head_only,
+        )
+
+    def _send_html(self, body: str, *, status: int = 200) -> None:
+        data = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _oauth_login_page(self, *, client_id: str, redirect_uri: str, code_challenge: str,
+                          code_challenge_method: str, state: str, error: str = "") -> str:
+        def esc(v: str) -> str:
+            return html.escape(v, quote=True)
+        error_block = f'<p style="color:red">{html.escape(error)}</p>' if error else ""
+        return (
+            "<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'>"
+            "<title>Authorize MCP Server</title>"
+            "<style>body{font-family:sans-serif;max-width:380px;margin:4rem auto;padding:1rem}"
+            "input{width:100%;padding:.5rem;margin:.4rem 0;box-sizing:border-box}"
+            "button{width:100%;padding:.7rem;background:#0066cc;color:#fff;border:none;cursor:pointer}</style>"
+            "</head><body>"
+            f"<h2>Authorize Coding Tools MCP</h2>"
+            f"<p>Client: <strong>{esc(client_id)}</strong></p>"
+            f"{error_block}"
+            "<form method='POST' action='/oauth/authorize'>"
+            f"<input type='hidden' name='client_id' value='{esc(client_id)}'>"
+            f"<input type='hidden' name='redirect_uri' value='{esc(redirect_uri)}'>"
+            f"<input type='hidden' name='code_challenge' value='{esc(code_challenge)}'>"
+            f"<input type='hidden' name='code_challenge_method' value='{esc(code_challenge_method)}'>"
+            f"<input type='hidden' name='state' value='{esc(state)}'>"
+            "<label>Password<input type='password' name='password' autocomplete='current-password' required></label>"
+            "<button type='submit'>Authorize</button>"
+            "</form></body></html>"
+        )
+
+    def _read_oauth_body(self) -> bytes | None:
+        raw_len = self.headers.get("Content-Length")
+        if raw_len is None:
+            self.send_json({"error": "Content-Length required"}, status=411)
+            return None
+        try:
+            length = int(raw_len)
+        except ValueError:
+            self.send_json({"error": "Invalid Content-Length"}, status=400)
+            return None
+        if not (0 <= length <= OAUTH_MAX_BODY_BYTES):
+            self.send_json({"error": "Request body too large"}, status=413)
+            return None
+        return self.rfile.read(length)
+
+    def handle_oauth_authorize_get(self) -> None:
+        cfg = self.runtime.oauth_config
+        if cfg is None:
+            self.send_json({"error": "OAuth not configured"}, status=404)
+            return
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query, keep_blank_values=True)
+
+        def _p(k: str) -> str:
+            v = params.get(k)
+            return v[0] if v else ""
+
+        client_id = _p("client_id")
+        redirect_uri = _p("redirect_uri")
+        code_challenge = _p("code_challenge")
+        code_challenge_method = _p("code_challenge_method")
+        state = _p("state")
+
+        if _p("response_type") != "code":
+            self._send_html("<h2>Error</h2><p>response_type must be 'code'</p>", status=400)
+            return
+        if not secrets.compare_digest(client_id, cfg.client_id):
+            self._send_html("<h2>Error</h2><p>Unknown client_id</p>", status=400)
+            return
+        if code_challenge_method != "S256" or not code_challenge:
+            self._send_html("<h2>Error</h2><p>code_challenge_method must be S256 and code_challenge is required</p>", status=400)
+            return
+
+        self._send_html(self._oauth_login_page(
+            client_id=client_id, redirect_uri=redirect_uri, code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method, state=state,
+        ))
+
+    def handle_oauth_authorize_post(self) -> None:
+        cfg = self.runtime.oauth_config
+        if cfg is None:
+            self.send_json({"error": "OAuth not configured"}, status=404)
+            return
+        body = self._read_oauth_body()
+        if body is None:
+            return
+        params = urllib.parse.parse_qs(body.decode("utf-8", errors="replace"), keep_blank_values=True)
+
+        def _p(k: str) -> str:
+            v = params.get(k)
+            return v[0] if v else ""
+
+        client_id = _p("client_id")
+        redirect_uri = _p("redirect_uri")
+        code_challenge = _p("code_challenge")
+        code_challenge_method = _p("code_challenge_method")
+        state = _p("state")
+        password = _p("password")
+
+        if not secrets.compare_digest(client_id, cfg.client_id):
+            self._send_html(self._oauth_login_page(
+                client_id=client_id, redirect_uri=redirect_uri, code_challenge=code_challenge,
+                code_challenge_method=code_challenge_method, state=state, error="Invalid client",
+            ), status=400)
+            return
+        if code_challenge_method != "S256" or not code_challenge:
+            self._send_html(self._oauth_login_page(
+                client_id=client_id, redirect_uri=redirect_uri, code_challenge=code_challenge,
+                code_challenge_method=code_challenge_method, state=state, error="Invalid PKCE parameters",
+            ), status=400)
+            return
+        if not secrets.compare_digest(password, cfg.password):
+            self._send_html(self._oauth_login_page(
+                client_id=client_id, redirect_uri=redirect_uri, code_challenge=code_challenge,
+                code_challenge_method=code_challenge_method, state=state, error="Invalid password",
+            ), status=401)
+            return
+
+        code = secrets.token_urlsafe(32)
+        now = time.time()
+        with self.runtime._pending_codes_lock:
+            expired = [k for k, v in self.runtime._pending_codes.items() if v["expires_at"] < now]
+            for k in expired:
+                del self.runtime._pending_codes[k]
+            self.runtime._pending_codes[code] = {
+                "code_challenge": code_challenge,
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+                "state": state,
+                "expires_at": now + OAUTH_CODE_TTL_SECONDS,
+            }
+
+        qs = urllib.parse.urlencode({"code": code, **({"state": state} if state else {})})
+        sep = "&" if "?" in redirect_uri else "?"
+        location = redirect_uri + sep + qs
+        self.send_response(302)
+        self.send_header("Location", location)
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def handle_oauth_token(self) -> None:
+        cfg = self.runtime.oauth_config
+        if cfg is None:
+            self.send_json({"error": "unsupported_grant_type"}, status=400)
+            return
+        body = self._read_oauth_body()
+        if body is None:
+            return
+        content_type = self.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        if content_type != "application/x-www-form-urlencoded":
+            self.send_json({"error": "invalid_request", "error_description": "Content-Type must be application/x-www-form-urlencoded"}, status=400)
+            return
+        params = urllib.parse.parse_qs(body.decode("utf-8", errors="replace"), keep_blank_values=True)
+
+        def _p(k: str) -> str:
+            v = params.get(k)
+            return v[0] if v else ""
+
+        grant_type = _p("grant_type")
+        code = _p("code")
+        redirect_uri = _p("redirect_uri")
+        code_verifier = _p("code_verifier")
+        client_id = _p("client_id")
+        client_secret = _p("client_secret")
+
+        # Also accept HTTP Basic auth for client credentials
+        auth_header = self.headers.get("Authorization", "")
+        if auth_header.startswith("Basic ") and (not client_id or not client_secret):
+            try:
+                decoded = base64.b64decode(auth_header[6:]).decode("utf-8")
+                basic_id, _, basic_secret = decoded.partition(":")
+                if not client_id:
+                    client_id = urllib.parse.unquote(basic_id)
+                if not client_secret:
+                    client_secret = urllib.parse.unquote(basic_secret)
+            except Exception:  # noqa: BLE001
+                pass
+
+        def _err(error: str, description: str) -> None:
+            self.send_json({"error": error, "error_description": description}, status=400)
+
+        if grant_type != "authorization_code":
+            _err("unsupported_grant_type", "Only authorization_code is supported")
+            return
+        if not secrets.compare_digest(client_id, cfg.client_id):
+            _err("invalid_client", "Unknown client_id")
+            return
+        if not secrets.compare_digest(client_secret, cfg.client_secret):
+            _err("invalid_client", "Invalid client_secret")
+            return
+        if not code:
+            _err("invalid_grant", "code is required")
+            return
+        if not code_verifier or not (43 <= len(code_verifier) <= 128) or not re.fullmatch(r"[A-Za-z0-9\-._~]+", code_verifier):
+            _err("invalid_grant", "Invalid code_verifier")
+            return
+
+        with self.runtime._pending_codes_lock:
+            code_data = self.runtime._pending_codes.pop(code, None)
+
+        if code_data is None:
+            _err("invalid_grant", "Unknown or already-used authorization code")
+            return
+        if time.time() > code_data["expires_at"]:
+            _err("invalid_grant", "Authorization code expired")
+            return
+        if not secrets.compare_digest(code_data["client_id"], client_id):
+            _err("invalid_grant", "client_id mismatch")
+            return
+        if not secrets.compare_digest(code_data["redirect_uri"], redirect_uri):
+            _err("invalid_grant", "redirect_uri mismatch")
+            return
+        if not _verify_pkce(code_verifier, code_data["code_challenge"]):
+            _err("invalid_grant", "PKCE verification failed")
+            return
+
+        access_token = _create_oauth_token(cfg)
+        self.send_json({"access_token": access_token, "token_type": "Bearer", "expires_in": cfg.token_ttl})
 
     def send_cors_headers(self) -> None:
         origin = self.headers.get("Origin")
@@ -4104,9 +4456,53 @@ class RuntimeHTTPServer(http.server.ThreadingHTTPServer):
 def run_http(args: argparse.Namespace) -> int:
     workspace = Path(args.workspace or os.environ.get("CODING_TOOLS_MCP_WORKSPACE") or os.getcwd())
     auth_token = args.auth_token or os.environ.get(f"{ENV_PREFIX}_AUTH_TOKEN") or None
-    if not auth_token and not is_loopback_bind_host(str(args.host)):
+
+    oauth_config: OAuthConfig | None = None
+    oauth_mode = getattr(args, "oauth_mode", False) or os.environ.get(f"{ENV_PREFIX}_OAUTH_MODE") == "1"
+    if oauth_mode:
+        client_id = os.environ.get(f"{ENV_PREFIX}_OAUTH_CLIENT_ID") or ""
+        client_secret = os.environ.get(f"{ENV_PREFIX}_OAUTH_CLIENT_SECRET") or ""
+        password = os.environ.get(f"{ENV_PREFIX}_OAUTH_PASSWORD") or ""
+        server_url = os.environ.get(f"{ENV_PREFIX}_SERVER_URL") or ""
+        if not all([client_id, client_secret, password, server_url]):
+            print(
+                "ERROR: --oauth-mode requires CODING_TOOLS_MCP_OAUTH_CLIENT_ID, "
+                "CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET, CODING_TOOLS_MCP_OAUTH_PASSWORD, "
+                "and CODING_TOOLS_MCP_SERVER_URL.",
+                file=sys.stderr,
+            )
+            return 2
+        raw_secret = os.environ.get(f"{ENV_PREFIX}_OAUTH_TOKEN_SECRET") or ""
+        if raw_secret:
+            try:
+                token_secret = bytes.fromhex(raw_secret)
+            except ValueError:
+                print(
+                    f"ERROR: {ENV_PREFIX}_OAUTH_TOKEN_SECRET must be hex-encoded bytes.",
+                    file=sys.stderr,
+                )
+                return 2
+        else:
+            token_secret = secrets.token_bytes(32)
+        try:
+            token_ttl = int(os.environ.get(f"{ENV_PREFIX}_OAUTH_TOKEN_TTL") or OAUTH_TOKEN_TTL_SECONDS)
+        except ValueError:
+            token_ttl = OAUTH_TOKEN_TTL_SECONDS
+        oauth_config = OAuthConfig(
+            client_id=client_id,
+            client_secret=client_secret,
+            password=password,
+            server_url=server_url.rstrip("/"),
+            token_secret=token_secret,
+            token_ttl=token_ttl,
+        )
+        if auth_token:
+            print("WARNING: --auth-token is ignored when --oauth-mode is active.", file=sys.stderr)
+            auth_token = None
+
+    if not auth_token and not oauth_config and not is_loopback_bind_host(str(args.host)):
         print(
-            "ERROR: non-loopback HTTP binding requires --auth-token or CODING_TOOLS_MCP_AUTH_TOKEN.",
+            "ERROR: non-loopback HTTP binding requires --auth-token, CODING_TOOLS_MCP_AUTH_TOKEN, or --oauth-mode.",
             file=sys.stderr,
         )
         return 2
@@ -4116,6 +4512,7 @@ def run_http(args: argparse.Namespace) -> int:
         dangerously_skip_all_permissions=args.dangerously_skip_all_permissions,
         tool_profile=args.tool_profile,
         auth_token=auth_token,
+        oauth_config=oauth_config,
     )
     server = RuntimeHTTPServer((args.host, args.port), MCPHandler, runtime)
     if args.dangerously_skip_all_permissions:
@@ -4123,7 +4520,12 @@ def run_http(args: argparse.Namespace) -> int:
             "WARNING: --dangerously-skip-all-permissions is enabled; permission-gated operations will be auto-granted.",
             file=sys.stderr,
         )
-    auth_label = "bearer auth enabled" if runtime.auth_enabled() else "no auth token configured"
+    if oauth_config:
+        auth_label = f"oauth2 enabled (server_url={oauth_config.server_url})"
+    elif runtime.auth_token:
+        auth_label = "bearer auth enabled"
+    else:
+        auth_label = "no auth configured"
     print(f"{SERVER_NAME} listening on http://{args.host}:{args.port}/mcp ({auth_label}, profile={args.tool_profile})", file=sys.stderr)
     try:
         server.serve_forever()
@@ -4232,6 +4634,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--auth-token",
         default=None,
         help=f"require Authorization: Bearer <token> on /mcp; defaults to {ENV_PREFIX}_AUTH_TOKEN",
+    )
+    parser.add_argument(
+        "--oauth-mode",
+        action="store_true",
+        default=False,
+        help=(
+            "enable OAuth 2.1 Authorization Code + PKCE; "
+            f"requires env vars {ENV_PREFIX}_OAUTH_CLIENT_ID, {ENV_PREFIX}_OAUTH_CLIENT_SECRET, "
+            f"{ENV_PREFIX}_OAUTH_PASSWORD, {ENV_PREFIX}_SERVER_URL"
+        ),
     )
     parser.add_argument(
         "--tool-profile",

--- a/docs/mcp-client-config.md
+++ b/docs/mcp-client-config.md
@@ -62,4 +62,4 @@ Configure the remote MCP client with:
 URL: https://<tunnel-host>/mcp
 ```
 
-Static bearer-token auth is available for MCP clients that support custom `Authorization` headers. Clients that cannot send custom bearer headers should use anonymous `read-only` mode only for local/testing tunnels, or be placed behind an external auth proxy for production use. See [Remote MCP](remote-mcp.md) for details.
+Static bearer-token auth is available for MCP clients that support custom `Authorization` headers. MCP clients that speak OAuth 2.1 Authorization Code + PKCE can use `--oauth-mode` instead, which publishes the standard discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`) and an HTML password gate on `/oauth/authorize`. Clients that cannot send custom bearer headers and do not speak OAuth should use anonymous `read-only` mode only for local/testing tunnels, or be placed behind an external auth proxy for production use. See [Remote MCP](remote-mcp.md) for details.

--- a/docs/remote-mcp.md
+++ b/docs/remote-mcp.md
@@ -2,7 +2,11 @@
 
 This guide exposes `coding-tools-mcp` to remote MCP clients through an HTTPS tunnel.
 
-The server implements Streamable HTTP at `/mcp`, publishes remote discovery metadata at `/.well-known/mcp.json` and `/.well-known/mcp/server-card.json`, and supports either no auth or static bearer-token auth on `/mcp`. OAuth-style authorization flows are intentionally out of scope for this server today, so clients that cannot send custom bearer headers should use anonymous `read-only` mode only for local/testing tunnels, or rely on an external auth proxy for production deployments.
+The server implements Streamable HTTP at `/mcp`, publishes remote discovery metadata at `/.well-known/mcp.json` and `/.well-known/mcp/server-card.json`, and supports three auth modes on `/mcp`:
+
+- `none` — no authentication; only acceptable for local/testing tunnels with the `read-only` profile.
+- `bearer` — static `Authorization: Bearer <token>` for clients that can send custom headers.
+- `oauth2` — OAuth 2.1 Authorization Code + PKCE for MCP clients that perform the standard discovery + authorization-code flow. Discovery metadata is published at `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`.
 
 ## Profile Choice
 
@@ -56,6 +60,55 @@ URL: https://<tunnel-host>/mcp
 Header: Authorization: Bearer <token>
 ```
 
+## MCP Clients With OAuth 2.1
+
+For MCP clients that perform OAuth 2.1 Authorization Code + PKCE discovery on the server URL, run the tunnel script with `CODING_TOOLS_MCP_AUTH_MODE=oauth`. The only env var you must set yourself is `CODING_TOOLS_MCP_SERVER_URL` (the script cannot know your tunnel's public URL); `CLIENT_ID`, `CLIENT_SECRET`, and `PASSWORD` are generated and printed for you on startup:
+
+```bash
+export CODING_TOOLS_MCP_SERVER_URL="https://<stable-tunnel-host>"
+
+CODING_TOOLS_MCP_AUTH_MODE=oauth \
+CODING_TOOLS_MCP_TOOL_PROFILE=read-only \
+scripts/tunnel.sh cloudflared /path/to/repo
+```
+
+The script adds `--oauth-mode` to the server and prints the OAuth metadata URLs and the generated credentials (copy them before they scroll out of view; they regenerate on every run unless you preset the env vars). The same flow works with `scripts/install.sh --tunnel <provider> --auth-mode oauth`. For local-only OAuth testing without a tunnel, `scripts/install.sh --start --auth-mode oauth` defaults `CODING_TOOLS_MCP_SERVER_URL` to `http://127.0.0.1:<port>`.
+
+Required:
+
+- `CODING_TOOLS_MCP_SERVER_URL` — public base URL (no trailing `/mcp`); used as the `issuer`/`aud` claim in issued tokens and in discovery metadata. **Must match the tunnel's actual external URL.**
+
+Auto-generated if unset (override to keep stable values across restarts):
+
+- `CODING_TOOLS_MCP_OAUTH_CLIENT_ID` — the only client_id the server accepts.
+- `CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET` — paired with the client_id on `/oauth/token` (accepts `client_secret_post` or HTTP Basic).
+- `CODING_TOOLS_MCP_OAUTH_PASSWORD` — the password an operator types on the `/oauth/authorize` HTML form to grant the authorization code.
+
+Optional:
+
+- `CODING_TOOLS_MCP_OAUTH_TOKEN_SECRET` — hex-encoded HS256 signing key. Without it, a random key is generated per process and all tokens are invalidated on restart. Generate one with `python3 -c "import secrets; print(secrets.token_bytes(32).hex())"`.
+- `CODING_TOOLS_MCP_OAUTH_TOKEN_TTL` — access-token lifetime in seconds (default `2592000`, i.e. 30 days).
+
+Endpoints exposed when `--oauth-mode` is active:
+
+- `GET /.well-known/oauth-authorization-server` — RFC 8414 authorization-server metadata.
+- `GET /.well-known/oauth-protected-resource` — RFC 9728 protected-resource metadata.
+- `GET /oauth/authorize` — renders an HTML password prompt; only `response_type=code` and `code_challenge_method=S256` are accepted. Authorization codes expire after 5 minutes.
+- `POST /oauth/authorize` — accepts the password, issues a one-time code, and 302s back to `redirect_uri`.
+- `POST /oauth/token` — exchanges `grant_type=authorization_code` + `code_verifier` for a Bearer JWT.
+
+`/mcp` accepts the issued token as `Authorization: Bearer <token>`; unauthenticated requests get HTTP `401` with a `WWW-Authenticate` header pointing at the protected-resource metadata. `--auth-token` is ignored while OAuth is active.
+
+### Stable Tunnel URLs
+
+OAuth metadata and issued JWT claims pin the public URL at server start. Ephemeral tunnels (e.g. `cloudflared tunnel --url`, default ngrok, default devtunnel) generate a fresh random subdomain each run, so the URL the script advertises to clients will not match the tunnel's actual host after any restart. Use one of:
+
+- **cloudflared named tunnel** — `cloudflared tunnel create <name>` + `cloudflared tunnel route dns <name> mcp.example.com`, then set `CODING_TOOLS_MCP_SERVER_URL=https://mcp.example.com`.
+- **ngrok reserved domain** — claim a domain in the ngrok dashboard and either configure it in `~/.config/ngrok/ngrok.yml`, or run `ngrok` yourself (`ngrok http --domain=<reserved> 8765`) and set `CODING_TOOLS_MCP_SERVER_URL=https://<reserved>` before launching the server. The bundled `scripts/tunnel-ngrok.sh` runs `ngrok http http://127.0.0.1:$PORT` without extra flags, so to attach a reserved domain you either point ngrok at it via config or run ngrok separately and start the server with `coding-tools-mcp --oauth-mode` directly.
+- **devtunnel persistent tunnel** — `devtunnel create <id>` + `devtunnel port create <id> -p 8765 --protocol http`, then `devtunnel host <id>`.
+
+If you only need ephemeral testing, prefer `bearer` mode over `oauth`.
+
 ## Tunnel Scripts
 
 Each script starts `coding-tools-mcp` on `127.0.0.1` and then starts the selected tunnel provider. If the provider CLI is missing, the script asks before installing it.
@@ -70,11 +123,21 @@ Optional environment variables:
 
 ```bash
 CODING_TOOLS_MCP_AUTO_INSTALL_TUNNEL=1
-CODING_TOOLS_MCP_AUTH_MODE=bearer
+CODING_TOOLS_MCP_AUTH_MODE=bearer        # bearer | noauth | oauth
 CODING_TOOLS_MCP_PORT=8765
 CODING_TOOLS_MCP_TOOL_PROFILE=read-only
 CODING_TOOLS_MCP_AUTH_TOKEN=<existing-token>
 CODING_TOOLS_MCP_SERVER_BIN=coding-tools-mcp
+
+# Required when CODING_TOOLS_MCP_AUTH_MODE=oauth:
+CODING_TOOLS_MCP_SERVER_URL=https://<stable-tunnel-host>
+# Auto-generated and printed at startup if unset:
+CODING_TOOLS_MCP_OAUTH_CLIENT_ID=<client-id>
+CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET=<client-secret>
+CODING_TOOLS_MCP_OAUTH_PASSWORD=<authorize-page-password>
+# Optional (oauth):
+CODING_TOOLS_MCP_OAUTH_TOKEN_SECRET=<hex-encoded-32-bytes>
+CODING_TOOLS_MCP_OAUTH_TOKEN_TTL=2592000
 ```
 
 If the selected tunnel CLI is missing, the scripts prompt before installing it. `cloudflared` installs into `~/.local/bin` when Homebrew is unavailable; `ngrok` uses Homebrew or npm; `devtunnel` uses the Microsoft installer script.
@@ -103,8 +166,21 @@ curl "$BASE_URL/mcp" \
 
 Missing or wrong bearer tokens on `/mcp` should return HTTP `401`.
 
+For OAuth mode, the discovery endpoints should respond without auth:
+
+```bash
+curl "$BASE_URL/.well-known/oauth-authorization-server"
+curl "$BASE_URL/.well-known/oauth-protected-resource"
+```
+
+A `401` response from `/mcp` includes:
+
+```text
+WWW-Authenticate: Bearer realm="coding-tools-mcp", resource_metadata="<BASE_URL>/.well-known/oauth-protected-resource"
+```
+
 ## Security Notes
 
-Keep the server bound to `127.0.0.1` and expose only the tunnel URL. Non-loopback binding without a bearer token is rejected. Use HTTPS tunnel URLs, rotate tokens if they are shared, and do not use `full` or `compat-readonly-all` with untrusted clients.
+Keep the server bound to `127.0.0.1` and expose only the tunnel URL. Non-loopback binding is rejected unless a bearer token or `--oauth-mode` is configured. Use HTTPS tunnel URLs, rotate bearer tokens and OAuth client secrets if they are shared, set `CODING_TOOLS_MCP_OAUTH_TOKEN_SECRET` so OAuth tokens survive restarts only when you actually want that, and do not use `full` or `compat-readonly-all` with untrusted clients.
 
 Anonymous remote MCP tunnel testing exposes whatever the selected profile permits to anyone who can reach the tunnel URL. Use `read-only`, avoid sensitive workspaces, and stop the tunnel when testing is done.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ name = "coding-tools-mcp"
 version = "0.1.4"
 description = "Workspace-confined coding tools exposed as an MCP server."
 requires-python = ">=3.11"
+dependencies = [
+  "PyJWT>=2.8",
+]
 readme = "README.md"
 license = "LicenseRef-Coding-Tools-MCP-Source-Available"
 authors = [{ name = "Coding Tools MCP Contributors" }]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,7 +44,12 @@ Server options:
   --workspace PATH              Workspace to expose. Default: current dir.
   --port PORT                   Local HTTP port. Default: 8765.
   --profile PROFILE             Tool profile. Defaults: full local, read-only tunnel.
-  --auth-mode bearer|noauth     Defaults: noauth local, bearer tunnel.
+  --auth-mode bearer|noauth|oauth
+                                Defaults: noauth local, bearer tunnel. OAuth
+                                tunnel mode requires CODING_TOOLS_MCP_SERVER_URL
+                                (local --start defaults it to loopback).
+                                CLIENT_ID, CLIENT_SECRET, and PASSWORD are
+                                generated and printed if unset.
   --auth-token TOKEN            Bearer token. Generated if needed.
   --server-bin PATH             Use an existing coding-tools-mcp binary.
 
@@ -320,12 +325,39 @@ resolve_runtime_defaults() {
       AUTH_MODE="${AUTH_MODE:-bearer}"
       ;;
   esac
-  if [[ "$AUTH_MODE" != "" && "$AUTH_MODE" != "bearer" && "$AUTH_MODE" != "noauth" ]]; then
-    die "--auth-mode must be bearer or noauth"
-  fi
+  case "$AUTH_MODE" in
+    ""|bearer|noauth) ;;
+    oauth) require_oauth_env_install ;;
+    *) die "--auth-mode must be bearer, noauth, or oauth" ;;
+  esac
   if [[ "$AUTH_MODE" == "bearer" && -z "$AUTH_TOKEN" ]]; then
     AUTH_TOKEN="$(generate_token)"
   fi
+}
+
+require_oauth_env_install() {
+  if [[ -z "${CODING_TOOLS_MCP_SERVER_URL:-}" ]]; then
+    if [[ "$ACTION" == "start" ]]; then
+      export CODING_TOOLS_MCP_SERVER_URL="http://127.0.0.1:$PORT"
+    else
+      {
+        echo "--auth-mode oauth requires CODING_TOOLS_MCP_SERVER_URL"
+        echo "(the public base URL the tunnel will terminate at, e.g. https://mcp.example.com)."
+        echo "See docs/remote-mcp.md for details."
+      } >&2
+      exit 2
+    fi
+  fi
+  if [[ -z "${CODING_TOOLS_MCP_OAUTH_CLIENT_ID:-}" ]]; then
+    CODING_TOOLS_MCP_OAUTH_CLIENT_ID="$(generate_token)"
+  fi
+  if [[ -z "${CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET:-}" ]]; then
+    CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET="$(generate_token)"
+  fi
+  if [[ -z "${CODING_TOOLS_MCP_OAUTH_PASSWORD:-}" ]]; then
+    CODING_TOOLS_MCP_OAUTH_PASSWORD="$(generate_token)"
+  fi
+  export CODING_TOOLS_MCP_OAUTH_CLIENT_ID CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET CODING_TOOLS_MCP_OAUTH_PASSWORD
 }
 
 server_args() {
@@ -335,9 +367,10 @@ server_args() {
     --port "$PORT"
     --tool-profile "$PROFILE"
   )
-  if [[ "$AUTH_MODE" == "bearer" ]]; then
-    args+=(--auth-token "$AUTH_TOKEN")
-  fi
+  case "$AUTH_MODE" in
+    bearer) args+=(--auth-token "$AUTH_TOKEN") ;;
+    oauth) args+=(--oauth-mode) ;;
+  esac
   printf "%s\0" "${args[@]}"
 }
 
@@ -348,11 +381,24 @@ Workspace: $WORKSPACE
 Tool profile: $PROFILE
 Auth mode: $AUTH_MODE
 EOF
-  if [[ "$AUTH_MODE" == "bearer" ]]; then
-    cat <<EOF
+  case "$AUTH_MODE" in
+    bearer)
+      cat <<EOF
 Header: Authorization: Bearer $AUTH_TOKEN
 EOF
-  fi
+      ;;
+    oauth)
+      local base="${CODING_TOOLS_MCP_SERVER_URL%/}"
+      cat <<EOF
+OAuth issuer: $base
+CODING_TOOLS_MCP_OAUTH_CLIENT_ID=$CODING_TOOLS_MCP_OAUTH_CLIENT_ID
+CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET=$CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET
+CODING_TOOLS_MCP_OAUTH_PASSWORD=$CODING_TOOLS_MCP_OAUTH_PASSWORD
+Authorization metadata: $base/.well-known/oauth-authorization-server
+Protected resource:     $base/.well-known/oauth-protected-resource
+EOF
+      ;;
+  esac
 }
 
 print_tunnel_config() {
@@ -366,15 +412,39 @@ Auth mode: $AUTH_MODE
 
 $label will print an HTTPS URL.
 EOF
-  if [[ "$AUTH_MODE" == "bearer" ]]; then
-    cat <<EOF
+  case "$AUTH_MODE" in
+    bearer)
+      cat <<EOF
 
 Generic MCP clients that support custom headers should use:
 URL: https://<$host_placeholder>/mcp
 Header: Authorization: Bearer $AUTH_TOKEN
 EOF
-  else
-    cat <<EOF
+      ;;
+    oauth)
+      local base="${CODING_TOOLS_MCP_SERVER_URL%/}"
+      cat <<EOF
+
+OAuth 2.1 Authorization Code + PKCE is active. Configure your MCP client
+with the following values (copy these now -- they are regenerated each run
+unless you preset the env vars):
+
+CODING_TOOLS_MCP_SERVER_URL=$base
+CODING_TOOLS_MCP_OAUTH_CLIENT_ID=$CODING_TOOLS_MCP_OAUTH_CLIENT_ID
+CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET=$CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET
+CODING_TOOLS_MCP_OAUTH_PASSWORD=$CODING_TOOLS_MCP_OAUTH_PASSWORD
+
+Authorization metadata: $base/.well-known/oauth-authorization-server
+Protected resource:     $base/.well-known/oauth-protected-resource
+MCP endpoint:           $base/mcp
+
+The tunnel below must terminate at $base. Ephemeral tunnels do not work
+with OAuth -- use a named cloudflared tunnel, an ngrok reserved domain,
+or a persistent devtunnel so the external URL matches across restarts.
+EOF
+      ;;
+    *)
+      cat <<EOF
 
 Remote MCP client URL:
 https://<$host_placeholder>/mcp
@@ -382,7 +452,8 @@ https://<$host_placeholder>/mcp
 No Authorization header is used. Keep this profile read-only unless you
 understand the risk of exposing this tunnel publicly.
 EOF
-  fi
+      ;;
+  esac
 }
 
 install_package() {

--- a/scripts/tunnel-cloudflared.sh
+++ b/scripts/tunnel-cloudflared.sh
@@ -9,15 +9,22 @@ PORT="${CODING_TOOLS_MCP_PORT:-8765}"
 PROFILE="${CODING_TOOLS_MCP_TOOL_PROFILE:-read-only}"
 SERVER_BIN="${CODING_TOOLS_MCP_SERVER_BIN:-coding-tools-mcp}"
 AUTH_MODE="${CODING_TOOLS_MCP_AUTH_MODE:-bearer}"
-TOKEN="${CODING_TOOLS_MCP_AUTH_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')}"
+TOKEN=""
 
-if [[ "$AUTH_MODE" != "bearer" && "$AUTH_MODE" != "noauth" ]]; then
-  echo "CODING_TOOLS_MCP_AUTH_MODE must be bearer or noauth" >&2
-  exit 2
-fi
-if [[ "$AUTH_MODE" == "bearer" ]]; then
-  export CODING_TOOLS_MCP_AUTH_TOKEN="$TOKEN"
-fi
+case "$AUTH_MODE" in
+  bearer)
+    TOKEN="${CODING_TOOLS_MCP_AUTH_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')}"
+    export CODING_TOOLS_MCP_AUTH_TOKEN="$TOKEN"
+    ;;
+  noauth) ;;
+  oauth)
+    require_oauth_env || exit 2
+    ;;
+  *)
+    echo "CODING_TOOLS_MCP_AUTH_MODE must be bearer, noauth, or oauth" >&2
+    exit 2
+    ;;
+esac
 
 ensure_tunnel_command cloudflared
 start_coding_tools_mcp "$WORKSPACE" "$PORT" "$PROFILE" "$AUTH_MODE" "$TOKEN" "$SERVER_BIN"

--- a/scripts/tunnel-common.sh
+++ b/scripts/tunnel-common.sh
@@ -125,6 +125,27 @@ ensure_tunnel_command() {
   fi
 }
 
+require_oauth_env() {
+  if [[ -z "${CODING_TOOLS_MCP_SERVER_URL:-}" ]]; then
+    {
+      echo "CODING_TOOLS_MCP_AUTH_MODE=oauth requires CODING_TOOLS_MCP_SERVER_URL"
+      echo "(the public base URL the tunnel will terminate at, e.g. https://mcp.example.com)."
+      echo "See docs/remote-mcp.md for details."
+    } >&2
+    return 1
+  fi
+  if [[ -z "${CODING_TOOLS_MCP_OAUTH_CLIENT_ID:-}" ]]; then
+    CODING_TOOLS_MCP_OAUTH_CLIENT_ID="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+  fi
+  if [[ -z "${CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET:-}" ]]; then
+    CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+  fi
+  if [[ -z "${CODING_TOOLS_MCP_OAUTH_PASSWORD:-}" ]]; then
+    CODING_TOOLS_MCP_OAUTH_PASSWORD="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+  fi
+  export CODING_TOOLS_MCP_OAUTH_CLIENT_ID CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET CODING_TOOLS_MCP_OAUTH_PASSWORD
+}
+
 start_coding_tools_mcp() {
   local workspace="$1"
   local port="$2"
@@ -138,9 +159,10 @@ start_coding_tools_mcp() {
     --port "$port"
     --tool-profile "$profile"
   )
-  if [[ "$auth_mode" == "bearer" ]]; then
-    args+=(--auth-token "$token")
-  fi
+  case "$auth_mode" in
+    bearer) args+=(--auth-token "$token") ;;
+    oauth) args+=(--oauth-mode) ;;
+  esac
 
   "$server_bin" "${args[@]}" &
   SERVER_PID=$!
@@ -163,8 +185,9 @@ Auth mode: $auth_mode
 $label will print an HTTPS URL.
 EOF
 
-  if [[ "$auth_mode" == "bearer" ]]; then
-    cat <<EOF
+  case "$auth_mode" in
+    bearer)
+      cat <<EOF
 
 Generic MCP clients that support custom headers should use:
 URL: https://<$host_placeholder>/mcp
@@ -174,8 +197,32 @@ Remote MCP clients that cannot send custom bearer headers should use
 CODING_TOOLS_MCP_AUTH_MODE=noauth only with read-only local/testing tunnels,
 or rely on an external auth proxy for authenticated production deployments.
 EOF
-  else
-    cat <<EOF
+      ;;
+    oauth)
+      local base="${CODING_TOOLS_MCP_SERVER_URL%/}"
+      cat <<EOF
+
+OAuth 2.1 Authorization Code + PKCE is active. Configure your MCP client
+with the following values (copy these now -- they are regenerated each run
+unless you preset the env vars):
+
+CODING_TOOLS_MCP_SERVER_URL=$base
+CODING_TOOLS_MCP_OAUTH_CLIENT_ID=$CODING_TOOLS_MCP_OAUTH_CLIENT_ID
+CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET=$CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET
+CODING_TOOLS_MCP_OAUTH_PASSWORD=$CODING_TOOLS_MCP_OAUTH_PASSWORD
+
+Authorization metadata: $base/.well-known/oauth-authorization-server
+Protected resource:     $base/.well-known/oauth-protected-resource
+MCP endpoint:           $base/mcp
+
+The tunnel below must terminate at $base. Ephemeral tunnels (random
+subdomain per run) do not work with OAuth -- use a named cloudflared
+tunnel, an ngrok reserved domain, or a persistent devtunnel so the
+external URL matches CODING_TOOLS_MCP_SERVER_URL across restarts.
+EOF
+      ;;
+    *)
+      cat <<EOF
 
 Remote MCP client URL:
 https://<$host_placeholder>/mcp
@@ -183,5 +230,6 @@ https://<$host_placeholder>/mcp
 No Authorization header is used. Keep this profile read-only unless you
 understand the risk of exposing this tunnel publicly.
 EOF
-  fi
+      ;;
+  esac
 }

--- a/scripts/tunnel-devtunnel.sh
+++ b/scripts/tunnel-devtunnel.sh
@@ -9,15 +9,22 @@ PORT="${CODING_TOOLS_MCP_PORT:-8765}"
 PROFILE="${CODING_TOOLS_MCP_TOOL_PROFILE:-read-only}"
 SERVER_BIN="${CODING_TOOLS_MCP_SERVER_BIN:-coding-tools-mcp}"
 AUTH_MODE="${CODING_TOOLS_MCP_AUTH_MODE:-bearer}"
-TOKEN="${CODING_TOOLS_MCP_AUTH_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')}"
+TOKEN=""
 
-if [[ "$AUTH_MODE" != "bearer" && "$AUTH_MODE" != "noauth" ]]; then
-  echo "CODING_TOOLS_MCP_AUTH_MODE must be bearer or noauth" >&2
-  exit 2
-fi
-if [[ "$AUTH_MODE" == "bearer" ]]; then
-  export CODING_TOOLS_MCP_AUTH_TOKEN="$TOKEN"
-fi
+case "$AUTH_MODE" in
+  bearer)
+    TOKEN="${CODING_TOOLS_MCP_AUTH_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')}"
+    export CODING_TOOLS_MCP_AUTH_TOKEN="$TOKEN"
+    ;;
+  noauth) ;;
+  oauth)
+    require_oauth_env || exit 2
+    ;;
+  *)
+    echo "CODING_TOOLS_MCP_AUTH_MODE must be bearer, noauth, or oauth" >&2
+    exit 2
+    ;;
+esac
 
 ensure_tunnel_command devtunnel
 start_coding_tools_mcp "$WORKSPACE" "$PORT" "$PROFILE" "$AUTH_MODE" "$TOKEN" "$SERVER_BIN"

--- a/scripts/tunnel-ngrok.sh
+++ b/scripts/tunnel-ngrok.sh
@@ -9,15 +9,22 @@ PORT="${CODING_TOOLS_MCP_PORT:-8765}"
 PROFILE="${CODING_TOOLS_MCP_TOOL_PROFILE:-read-only}"
 SERVER_BIN="${CODING_TOOLS_MCP_SERVER_BIN:-coding-tools-mcp}"
 AUTH_MODE="${CODING_TOOLS_MCP_AUTH_MODE:-bearer}"
-TOKEN="${CODING_TOOLS_MCP_AUTH_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')}"
+TOKEN=""
 
-if [[ "$AUTH_MODE" != "bearer" && "$AUTH_MODE" != "noauth" ]]; then
-  echo "CODING_TOOLS_MCP_AUTH_MODE must be bearer or noauth" >&2
-  exit 2
-fi
-if [[ "$AUTH_MODE" == "bearer" ]]; then
-  export CODING_TOOLS_MCP_AUTH_TOKEN="$TOKEN"
-fi
+case "$AUTH_MODE" in
+  bearer)
+    TOKEN="${CODING_TOOLS_MCP_AUTH_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')}"
+    export CODING_TOOLS_MCP_AUTH_TOKEN="$TOKEN"
+    ;;
+  noauth) ;;
+  oauth)
+    require_oauth_env || exit 2
+    ;;
+  *)
+    echo "CODING_TOOLS_MCP_AUTH_MODE must be bearer, noauth, or oauth" >&2
+    exit 2
+    ;;
+esac
 
 ensure_tunnel_command ngrok
 start_coding_tools_mcp "$WORKSPACE" "$PORT" "$PROFILE" "$AUTH_MODE" "$TOKEN" "$SERVER_BIN"

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -28,11 +28,15 @@ Defaults:
 
 Environment:
   CODING_TOOLS_MCP_AUTO_INSTALL_TUNNEL=1  install missing tunnel CLI without prompting
-  CODING_TOOLS_MCP_AUTH_MODE=bearer       bearer or noauth
+  CODING_TOOLS_MCP_AUTH_MODE=bearer       bearer, noauth, or oauth
   CODING_TOOLS_MCP_PORT=8765
   CODING_TOOLS_MCP_TOOL_PROFILE=read-only
   CODING_TOOLS_MCP_AUTH_TOKEN=<existing-token>
   CODING_TOOLS_MCP_SERVER_BIN=coding-tools-mcp
+
+OAuth mode requires CODING_TOOLS_MCP_SERVER_URL. CLIENT_ID, CLIENT_SECRET,
+and PASSWORD are generated and printed at startup if unset. See
+docs/remote-mcp.md.
 EOF
     ;;
   *)


### PR DESCRIPTION
Clean-author replacement for #1.\n\nThis PR has the same final file tree as #1, squashed into a single xyTom-authored commit with no Claude/Anthropic author metadata.\n\nValidation performed:\n- /tmp/coding-tools-pr-venv/bin/python -m pytest tests/compliance --ignore=tests/compliance/fixtures: 88 passed\n- /tmp/coding-tools-pr-venv/bin/python -m ruff check coding_tools_mcp tests/compliance --exclude tests/compliance/fixtures\n- bash -n scripts/install.sh scripts/tunnel.sh scripts/tunnel-common.sh scripts/tunnel-cloudflared.sh scripts/tunnel-ngrok.sh scripts/tunnel-devtunnel.sh\n- OAuth authorization-code + PKCE smoke test