### PR TITLE
feat: add desktop client mvp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,15 @@ successful_apply_patch_blocks.txt
 pi/
 codex/
 opencode/
+tmp-run/
+.agents/
+.claude/
+.mcp-probe-kit/
+docs/.mcp-probe/
+docs/graph-insights/latest.json
+docs/graph-insights/latest.md
+AGENTS.md
+CLAUDE.md
+docs/project-context.md
+docs/project-context/
+docs/specs/

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ If dependencies are missing, install the runtime in editable mode:
 python -m pip install -e ".[dev]"
 ```
 
+Run the desktop client MVP:
+
+```bash
+python -m pip install -e ".[desktop]"
+python apps/desktop-client/main.py
+```
+
 HTTP endpoint:
 
 ```text

--- a/apps/desktop-client/README.md
+++ b/apps/desktop-client/README.md
@@ -1,0 +1,46 @@
+# MCP 桌面客户端
+
+这是 `coding-tools-mcp` 的 Python 桌面客户端 MVP，核心目标是让研发同学用一个中文界面完成：
+
+- 管理多个 Workspace
+- 配置公网暴露地址，当前支持 FRP 和 Cloudflare
+- 配置 OAuth / Bearer / NoAuth
+- 启动和停止本地 MCP 运行时
+- 查看运行日志和当前入口地址
+- 直接复制 ChatGPT 自定义 MCP 应用需要填写的核心字段
+
+## 运行
+
+```bash
+python apps/desktop-client/main.py
+```
+
+## 依赖
+
+- Python 3.11+
+- PySide6
+- psutil
+- `uvx` 或 `coding-tools-mcp` 已在 PATH 中可用
+
+## ChatGPT 接入
+
+当认证方式选择 `oauth` 后，界面里会直接展示并支持复制：
+
+- 连接地址
+- OAuth 客户端 ID
+- OAuth 客户端密钥
+- 授权口令
+
+如果你使用 FRP，只需要把 Workspace、本地端口、FRP 子域名和服务器域名配好，再启动运行时即可。
+
+如果你使用 Cloudflare，有两种模式：
+
+- 临时隧道：使用 `cloudflared tunnel --url`，启动后自动分配一个 `trycloudflare.com` 公网地址
+- 固定域名：使用 `Tunnel Token` 启动命名隧道，并在界面里填写固定公网地址
+
+## 当前限制
+
+- 当前只接通了 FRP 和 Cloudflare
+- `Ngrok`、`Dev Tunnel` 还没有实现真实隧道启动能力
+- Cloudflare 命名隧道模式依赖你提前在 Cloudflare 仪表盘里配置好 tunnel 和 hostname
+- Cloudflare 命名隧道模式下，本地服务地址需要和 Cloudflare Tunnel 的 ingress 目标一致，通常是 `http://127.0.0.1:<本地端口>`

--- a/apps/desktop-client/main.py
+++ b/apps/desktop-client/main.py
@@ -1,0 +1,5 @@
+from mcp_desktop_client.app import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/desktop-client/mcp_desktop_client/__init__.py
+++ b/apps/desktop-client/mcp_desktop_client/__init__.py
@@ -1,0 +1,1 @@
+"""MCP desktop client package."""

--- a/apps/desktop-client/mcp_desktop_client/app.py
+++ b/apps/desktop-client/mcp_desktop_client/app.py
@@ -1,0 +1,844 @@
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtCore import QObject, QThread, QTimer, Qt, Signal
+from PySide6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QFormLayout,
+    QFrame,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QComboBox,
+    QSpinBox,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .models import WorkspaceProfile, build_profile
+from .runtime import RuntimeManager
+from .storage import load_profiles, log_dir_for_profile, save_profiles
+from .theme import STYLESHEET
+
+
+class RuntimeJob(QObject):
+    finished = Signal(str, object, str)
+
+    def __init__(self, runtime: RuntimeManager, profile: WorkspaceProfile, action: str) -> None:
+        super().__init__()
+        self.runtime = runtime
+        self.profile = profile
+        self.action = action
+
+    def run(self) -> None:
+        try:
+            if self.action == "start":
+                status = self.runtime.start(self.profile)
+            else:
+                status = self.runtime.stop(self.profile)
+            self.finished.emit(self.action, status, "")
+        except Exception as exc:  # noqa: BLE001
+            self.finished.emit(self.action, None, str(exc))
+
+
+class MainWindow(QMainWindow):
+    TUNNEL_OPTIONS = [
+        ("frp", "FRP"),
+        ("cloudflare", "Cloudflare"),
+    ]
+    CLOUDFLARE_MODE_OPTIONS = [
+        ("quick", "临时隧道"),
+        ("named", "固定域名"),
+    ]
+    AUTH_OPTIONS = [
+        ("oauth", "OAuth"),
+        ("bearer", "Bearer Token"),
+        ("noauth", "不启用认证"),
+    ]
+    TOOL_PROFILE_OPTIONS = [
+        ("full", "完整工具"),
+        ("read-only", "只读工具"),
+        ("compat-readonly-all", "兼容只读"),
+    ]
+    PERMISSION_MODE_OPTIONS = [
+        ("trusted", "受信任"),
+        ("safe", "安全受限"),
+        ("dangerous", "完全放开"),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Coding Tools MCP Desktop")
+        self.resize(1460, 920)
+        self.runtime = RuntimeManager()
+        self.profiles = load_profiles()
+        self.current_profile: WorkspaceProfile | None = None
+        self._runtime_thread: QThread | None = None
+        self._runtime_job: RuntimeJob | None = None
+        self._busy_profile_id: str | None = None
+        self._busy_action: str | None = None
+        self._busy_dots = 0
+        self._busy_timer = QTimer(self)
+        self._busy_timer.setInterval(350)
+        self._busy_timer.timeout.connect(self._tick_busy_indicator)
+        self._build_ui()
+        self._populate_workspace_list()
+        if self.profiles:
+            self.workspace_list.setCurrentRow(0)
+        else:
+            self._clear_panel()
+
+    def _build_ui(self) -> None:
+        root = QWidget()
+        layout = QHBoxLayout(root)
+        layout.setContentsMargins(18, 18, 18, 18)
+        layout.setSpacing(18)
+
+        sidebar = QFrame()
+        sidebar.setObjectName("Sidebar")
+        sidebar_layout = QVBoxLayout(sidebar)
+        sidebar_layout.setContentsMargins(18, 18, 18, 18)
+        sidebar_layout.setSpacing(14)
+
+        eyebrow = QLabel("工作区控制台")
+        eyebrow.setObjectName("Eyebrow")
+        title = QLabel("MCP 桌面客户端")
+        title.setObjectName("Title")
+        subtitle = QLabel("围绕 Workspace 管理公网接入、认证方式和本地运行状态。")
+        subtitle.setWordWrap(True)
+        subtitle.setStyleSheet("color:#667085; font-size:14px;")
+
+        actions = QHBoxLayout()
+        add_button = QPushButton("添加工作区")
+        add_button.clicked.connect(self._add_workspace)
+        self.delete_button = QPushButton("删除")
+        self.delete_button.setProperty("secondary", True)
+        self.delete_button.clicked.connect(self._delete_workspace)
+        refresh_button = QPushButton("刷新")
+        refresh_button.setProperty("secondary", True)
+        refresh_button.clicked.connect(self._refresh_current)
+        actions.addWidget(add_button)
+        actions.addWidget(self.delete_button)
+        actions.addWidget(refresh_button)
+
+        self.workspace_list = QListWidget()
+        self.workspace_list.currentRowChanged.connect(self._on_workspace_selected)
+
+        sidebar_layout.addWidget(eyebrow)
+        sidebar_layout.addWidget(title)
+        sidebar_layout.addWidget(subtitle)
+        sidebar_layout.addLayout(actions)
+        sidebar_layout.addWidget(self.workspace_list, 1)
+
+        panel = QFrame()
+        panel.setObjectName("Panel")
+        panel_layout = QVBoxLayout(panel)
+        panel_layout.setContentsMargins(22, 22, 22, 22)
+        panel_layout.setSpacing(16)
+
+        self.header_title = QLabel("先添加一个工作区")
+        self.header_title.setObjectName("Title")
+        self.header_title.setStyleSheet("font-size:24px;")
+        self.header_meta = QLabel("左侧添加工作区后，再配置公网地址和认证。")
+        self.header_meta.setStyleSheet("color:#667085; font-size:13px;")
+
+        header_actions = QHBoxLayout()
+        self.start_button = QPushButton("启动")
+        self.start_button.clicked.connect(self._start_runtime)
+        self.stop_button = QPushButton("停止")
+        self.stop_button.setProperty("secondary", True)
+        self.stop_button.clicked.connect(self._stop_runtime)
+        self.copy_button = QPushButton("复制 MCP 地址")
+        self.copy_button.setProperty("secondary", True)
+        self.copy_button.clicked.connect(self._copy_endpoint)
+        self.copy_frp_button = QPushButton("复制 FRP 片段")
+        self.copy_frp_button.setProperty("secondary", True)
+        self.copy_frp_button.clicked.connect(self._copy_frp_snippet)
+        header_actions.addWidget(self.start_button)
+        header_actions.addWidget(self.stop_button)
+        header_actions.addWidget(self.copy_button)
+        header_actions.addWidget(self.copy_frp_button)
+        header_actions.addStretch(1)
+
+        content = QGridLayout()
+        content.setHorizontalSpacing(16)
+        content.setVerticalSpacing(16)
+
+        self.workspace_group = self._build_workspace_group()
+        self.runtime_group = self._build_runtime_group()
+        self.auth_group = self._build_auth_group()
+        self.log_group = self._build_log_group()
+
+        content.addWidget(self.workspace_group, 0, 0)
+        content.addWidget(self.runtime_group, 0, 1)
+        content.addWidget(self.auth_group, 1, 0)
+        content.addWidget(self.log_group, 1, 1)
+        content.setColumnStretch(0, 1)
+        content.setColumnStretch(1, 1)
+
+        panel_layout.addWidget(self.header_title)
+        panel_layout.addWidget(self.header_meta)
+        panel_layout.addLayout(header_actions)
+        panel_layout.addLayout(content, 1)
+
+        layout.addWidget(sidebar, 1)
+        layout.addWidget(panel, 2)
+        self.setCentralWidget(root)
+        self._wire_live_updates()
+
+    def _build_workspace_group(self) -> QGroupBox:
+        box = QGroupBox("工作区与公网入口")
+        self.workspace_form = QFormLayout(box)
+
+        self.name_edit = QLineEdit()
+        self.path_edit = QLineEdit()
+        self.path_edit.setReadOnly(True)
+        self.tunnel_type = QComboBox()
+        self._fill_combo(self.tunnel_type, self.TUNNEL_OPTIONS)
+        self.tunnel_type.currentIndexChanged.connect(self._refresh_tunnel_fields)
+
+        self.public_url_label = QLabel("公网地址")
+        self.public_url_edit = QLineEdit()
+        self.public_url_edit.setPlaceholderText("Cloudflare 启动后会自动分配公网地址")
+        self.cloudflare_mode_label = QLabel("Cloudflare 模式")
+        self.cloudflare_mode = QComboBox()
+        self._fill_combo(self.cloudflare_mode, self.CLOUDFLARE_MODE_OPTIONS)
+        self.cloudflare_mode.currentIndexChanged.connect(self._refresh_tunnel_fields)
+        self.cloudflare_token_label = QLabel("Tunnel Token")
+        self.cloudflare_token_edit = QLineEdit()
+        self.cloudflare_token_edit.setPlaceholderText("命名隧道模式下填写 Cloudflare Tunnel Token")
+
+        self.frp_server_label = QLabel("FRP 服务器域名")
+        self.frp_server_edit = QLineEdit()
+        self.frp_server_edit.setPlaceholderText("例如：frp.example.com")
+
+        self.subdomain_label = QLabel("FRP 子域名")
+        self.subdomain_edit = QLineEdit()
+        self.subdomain_edit.setPlaceholderText("例如：mcp")
+
+        self.workspace_form.addRow("名称", self.name_edit)
+        self.workspace_form.addRow("工作区路径", self.path_edit)
+        self.workspace_form.addRow("隧道方式", self.tunnel_type)
+        self.workspace_form.addRow(self.cloudflare_mode_label, self.cloudflare_mode)
+        self.workspace_form.addRow(self.public_url_label, self.public_url_edit)
+        self.workspace_form.addRow(self.cloudflare_token_label, self.cloudflare_token_edit)
+        self.workspace_form.addRow(self.frp_server_label, self.frp_server_edit)
+        self.workspace_form.addRow(self.subdomain_label, self.subdomain_edit)
+
+        self.endpoint_hint = QLabel("当前入口：-")
+        self.endpoint_hint.setWordWrap(True)
+        self.endpoint_hint.setStyleSheet("color:#667085;")
+        self.workspace_form.addRow("当前入口", self.endpoint_hint)
+
+        save_button = QPushButton("保存配置")
+        save_button.clicked.connect(self._save_current)
+        self.workspace_form.addRow(save_button)
+        return box
+
+    def _build_runtime_group(self) -> QGroupBox:
+        box = QGroupBox("运行时")
+        form = QFormLayout(box)
+
+        self.local_port = QSpinBox()
+        self.local_port.setMaximum(65535)
+        self.local_port.setMinimum(1000)
+
+        self.tool_profile = QComboBox()
+        self._fill_combo(self.tool_profile, self.TOOL_PROFILE_OPTIONS)
+
+        self.permission_mode = QComboBox()
+        self._fill_combo(self.permission_mode, self.PERMISSION_MODE_OPTIONS)
+
+        self.runtime_command = QLineEdit()
+        self.runtime_command.setPlaceholderText("可选，例如：coding-tools-mcp")
+
+        self.status_label = QLabel("未启动")
+        self.status_label.setStyleSheet("font-weight:700; color:#b42318;")
+
+        form.addRow("本地端口", self.local_port)
+        form.addRow("工具档位", self.tool_profile)
+        form.addRow("权限模式", self.permission_mode)
+        form.addRow("自定义命令", self.runtime_command)
+        form.addRow("状态", self.status_label)
+        return box
+
+    def _build_auth_group(self) -> QGroupBox:
+        box = QGroupBox("认证与 ChatGPT 接入")
+        layout = QVBoxLayout(box)
+
+        self.auth_form = QFormLayout()
+        self.auth_type = QComboBox()
+        self._fill_combo(self.auth_type, self.AUTH_OPTIONS)
+        self.auth_type.currentIndexChanged.connect(self._refresh_auth_fields)
+
+        self.oauth_client_id_label = QLabel("OAuth 客户端 ID")
+        self.oauth_client_id = QLineEdit()
+
+        self.oauth_client_secret_label = QLabel("OAuth 客户端密钥")
+        self.oauth_client_secret = QLineEdit()
+
+        self.oauth_password_label = QLabel("授权口令")
+        self.oauth_password = QLineEdit()
+        self.oauth_password.setPlaceholderText("ChatGPT 首次授权时输入这个口令")
+
+        self.bearer_token_label = QLabel("Bearer Token")
+        self.bearer_token = QLineEdit()
+
+        self.auth_form.addRow("认证方式", self.auth_type)
+        self.auth_form.addRow(self.oauth_client_id_label, self.oauth_client_id)
+        self.auth_form.addRow(self.oauth_client_secret_label, self.oauth_client_secret)
+        self.auth_form.addRow(self.oauth_password_label, self.oauth_password)
+        self.auth_form.addRow(self.bearer_token_label, self.bearer_token)
+        layout.addLayout(self.auth_form)
+
+        self.oauth_actions = QWidget()
+        oauth_actions_layout = QHBoxLayout(self.oauth_actions)
+        oauth_actions_layout.setContentsMargins(0, 0, 0, 0)
+        oauth_actions_layout.setSpacing(10)
+        self.copy_client_id_button = QPushButton("复制客户端 ID")
+        self.copy_client_id_button.setProperty("secondary", True)
+        self.copy_client_id_button.clicked.connect(self._copy_oauth_client_id)
+        self.copy_client_secret_button = QPushButton("复制客户端密钥")
+        self.copy_client_secret_button.setProperty("secondary", True)
+        self.copy_client_secret_button.clicked.connect(self._copy_oauth_client_secret)
+        self.copy_oauth_password_button = QPushButton("复制授权口令")
+        self.copy_oauth_password_button.setProperty("secondary", True)
+        self.copy_oauth_password_button.clicked.connect(self._copy_oauth_password)
+        oauth_actions_layout.addWidget(self.copy_client_id_button)
+        oauth_actions_layout.addWidget(self.copy_client_secret_button)
+        oauth_actions_layout.addWidget(self.copy_oauth_password_button)
+        oauth_actions_layout.addStretch(1)
+        layout.addWidget(self.oauth_actions)
+
+        self.bearer_actions = QWidget()
+        bearer_actions_layout = QHBoxLayout(self.bearer_actions)
+        bearer_actions_layout.setContentsMargins(0, 0, 0, 0)
+        bearer_actions_layout.setSpacing(10)
+        self.copy_bearer_button = QPushButton("复制 Bearer Token")
+        self.copy_bearer_button.setProperty("secondary", True)
+        self.copy_bearer_button.clicked.connect(self._copy_bearer_token)
+        bearer_actions_layout.addWidget(self.copy_bearer_button)
+        bearer_actions_layout.addStretch(1)
+        layout.addWidget(self.bearer_actions)
+
+        self.auth_hint = QLabel("OAuth 模式下，ChatGPT 里填客户端 ID 和客户端密钥；首次授权时再输入授权口令。")
+        self.auth_hint.setWordWrap(True)
+        self.auth_hint.setStyleSheet("color:#667085;")
+        layout.addWidget(self.auth_hint)
+        return box
+
+    def _build_log_group(self) -> QGroupBox:
+        box = QGroupBox("日志与地址")
+        layout = QVBoxLayout(box)
+        self.endpoint_label = QLabel("公网 MCP 地址：-")
+        self.local_label = QLabel("本地 MCP 地址：-")
+        self.log_output = QTextEdit()
+        self.log_output.setReadOnly(True)
+        self.log_output.setMinimumHeight(220)
+        layout.addWidget(self.endpoint_label)
+        layout.addWidget(self.local_label)
+        layout.addWidget(self.log_output)
+        return box
+
+    def _wire_live_updates(self) -> None:
+        for widget in (
+            self.name_edit,
+            self.public_url_edit,
+            self.cloudflare_token_edit,
+            self.frp_server_edit,
+            self.subdomain_edit,
+            self.runtime_command,
+            self.oauth_client_id,
+            self.oauth_client_secret,
+            self.oauth_password,
+            self.bearer_token,
+        ):
+            widget.textChanged.connect(self._refresh_connection_view)
+        self.local_port.valueChanged.connect(self._refresh_connection_view)
+        self.tunnel_type.currentIndexChanged.connect(self._refresh_connection_view)
+        self.auth_type.currentIndexChanged.connect(self._refresh_connection_view)
+
+    def _populate_workspace_list(self) -> None:
+        self.workspace_list.clear()
+        for profile in self.profiles:
+            item = QListWidgetItem(self._workspace_summary(profile))
+            item.setData(Qt.ItemDataRole.UserRole, profile.id)
+            self.workspace_list.addItem(item)
+
+    def _on_workspace_selected(self, row: int) -> None:
+        if row < 0 or row >= len(self.profiles):
+            self.current_profile = None
+            self._clear_panel()
+            return
+        self.current_profile = self.profiles[row]
+        self._load_profile(self.current_profile)
+
+    def _load_profile(self, profile: WorkspaceProfile) -> None:
+        self.header_title.setText(profile.name)
+        self.header_meta.setText(profile.path)
+        self.name_edit.setText(profile.name)
+        self.path_edit.setText(profile.path)
+        self._set_combo_value(self.cloudflare_mode, profile.tunnel.cloudflare_mode)
+        self.public_url_edit.setText(self._profile_public_url_for_edit(profile))
+        self.cloudflare_token_edit.setText(profile.tunnel.cloudflare_token)
+        self.frp_server_edit.setText(profile.tunnel.frp_server)
+        self.subdomain_edit.setText(profile.tunnel.frp_subdomain)
+        self._set_combo_value(self.tunnel_type, profile.tunnel.type)
+        self.local_port.setValue(profile.runtime.local_port)
+        self._set_combo_value(self.tool_profile, profile.runtime.tool_profile)
+        self._set_combo_value(self.permission_mode, profile.runtime.permission_mode)
+        self.runtime_command.setText(profile.runtime.runtime_command)
+        self._set_combo_value(self.auth_type, profile.auth.type)
+        self.oauth_client_id.setText(profile.auth.oauth_client_id)
+        self.oauth_client_secret.setText(profile.auth.oauth_client_secret)
+        self.oauth_password.setText(profile.auth.oauth_password)
+        self.bearer_token.setText(profile.auth.bearer_token)
+        status = self.runtime.status(profile)
+        self._render_status(status)
+        self._load_logs(profile)
+        self._refresh_tunnel_fields()
+        self._refresh_auth_fields()
+        self._refresh_connection_view()
+        self._set_panel_enabled(True)
+
+    def _clear_panel(self) -> None:
+        self.header_title.setText("先添加一个工作区")
+        self.header_meta.setText("左侧添加工作区后，再配置公网地址和认证。")
+        self.name_edit.clear()
+        self.path_edit.clear()
+        self.public_url_edit.clear()
+        self.cloudflare_token_edit.clear()
+        self.frp_server_edit.clear()
+        self.subdomain_edit.clear()
+        self.oauth_client_id.clear()
+        self.oauth_client_secret.clear()
+        self.oauth_password.clear()
+        self.bearer_token.clear()
+        self.runtime_command.clear()
+        self.local_port.setValue(28766)
+        self._set_combo_value(self.tunnel_type, "frp")
+        self._set_combo_value(self.cloudflare_mode, "quick")
+        self._set_combo_value(self.tool_profile, "full")
+        self._set_combo_value(self.permission_mode, "trusted")
+        self._set_combo_value(self.auth_type, "oauth")
+        self.status_label.setText("未启动")
+        self.status_label.setStyleSheet("font-weight:700; color:#b42318;")
+        self.endpoint_label.setText("公网 MCP 地址：-")
+        self.local_label.setText("本地 MCP 地址：-")
+        self.endpoint_hint.setText("当前入口：-")
+        self.log_output.setPlainText("当前还没有日志。")
+        self._refresh_tunnel_fields()
+        self._refresh_auth_fields()
+        self._set_panel_enabled(False)
+
+    def _set_panel_enabled(self, enabled: bool) -> None:
+        for widget in (
+            self.workspace_group,
+            self.runtime_group,
+            self.auth_group,
+            self.log_group,
+            self.start_button,
+            self.stop_button,
+            self.copy_button,
+            self.copy_frp_button,
+            self.delete_button,
+        ):
+            widget.setEnabled(enabled)
+
+    def _save_current(self) -> None:
+        profile = self._require_profile()
+        profile.name = self.name_edit.text().strip() or "工作区"
+        profile.tunnel.type = self._combo_value(self.tunnel_type)
+        profile.tunnel.cloudflare_mode = self._combo_value(self.cloudflare_mode)
+        profile.tunnel.cloudflare_token = self.cloudflare_token_edit.text().strip()
+        if profile.tunnel.type == "frp":
+            profile.tunnel.public_url = self.public_url_edit.text().strip() or profile.tunnel.public_url
+        elif profile.tunnel.cloudflare_mode == "named":
+            profile.tunnel.public_url = self.public_url_edit.text().strip()
+        else:
+            profile.tunnel.public_url = ""
+        profile.tunnel.frp_server = self.frp_server_edit.text().strip() or profile.tunnel.frp_server
+        profile.tunnel.frp_subdomain = self.subdomain_edit.text().strip() or profile.tunnel.frp_subdomain
+        profile.runtime.local_port = self.local_port.value()
+        profile.runtime.tool_profile = self._combo_value(self.tool_profile)
+        profile.runtime.permission_mode = self._combo_value(self.permission_mode)
+        profile.runtime.runtime_command = self.runtime_command.text().strip()
+        profile.auth.type = self._combo_value(self.auth_type)
+        profile.auth.oauth_client_id = self.oauth_client_id.text().strip() or profile.auth.oauth_client_id
+        profile.auth.oauth_client_secret = self.oauth_client_secret.text().strip()
+        profile.auth.oauth_password = self.oauth_password.text().strip() or profile.auth.oauth_password
+        profile.auth.bearer_token = self.bearer_token.text().strip() or profile.auth.bearer_token
+        save_profiles(self.profiles)
+        self._populate_workspace_list()
+        self._restore_selection(profile.id)
+
+    def _add_workspace(self) -> None:
+        directory = QFileDialog.getExistingDirectory(self, "选择工作区目录")
+        if not directory:
+            return
+        profile = build_profile(directory)
+        self.profiles.append(profile)
+        save_profiles(self.profiles)
+        self._populate_workspace_list()
+        self.workspace_list.setCurrentRow(len(self.profiles) - 1)
+
+    def _delete_workspace(self) -> None:
+        profile = self._require_profile()
+        answer = QMessageBox.question(
+            self,
+            "删除工作区",
+            f"确定删除工作区“{profile.name}”吗？\n这不会删除磁盘目录，只会从客户端配置里移除。",
+        )
+        if answer != QMessageBox.StandardButton.Yes:
+            return
+        self.runtime.stop(profile)
+        current_index = self.workspace_list.currentRow()
+        self.profiles = [item for item in self.profiles if item.id != profile.id]
+        save_profiles(self.profiles)
+        self.current_profile = None
+        self._populate_workspace_list()
+        if self.profiles:
+            self.workspace_list.setCurrentRow(min(current_index, len(self.profiles) - 1))
+        else:
+            self._clear_panel()
+
+    def _start_runtime(self) -> None:
+        profile = self._require_profile()
+        self._save_current()
+        self._set_runtime_busy(True, "启动中")
+        self._run_runtime_job(profile, "start")
+
+    def _stop_runtime(self) -> None:
+        profile = self._require_profile()
+        self._set_runtime_busy(True, "停止中")
+        self._run_runtime_job(profile, "stop")
+
+    def _copy_endpoint(self) -> None:
+        self._save_current()
+        profile = self._require_profile()
+        endpoint = self.runtime.resolved_endpoint(profile) or self._draft_endpoint()
+        QApplication.clipboard().setText(endpoint)
+        self.statusBar().showMessage("已复制 MCP 地址到剪贴板", 3000)
+
+    def _copy_frp_snippet(self) -> None:
+        self._save_current()
+        profile = self._require_profile()
+        QApplication.clipboard().setText(profile.frp_proxy_snippet())
+        self.statusBar().showMessage("已复制 FRP 代理片段", 3000)
+
+    def _copy_oauth_client_id(self) -> None:
+        self._save_current()
+        QApplication.clipboard().setText(self.oauth_client_id.text().strip())
+        self.statusBar().showMessage("已复制 OAuth 客户端 ID", 3000)
+
+    def _copy_oauth_client_secret(self) -> None:
+        self._save_current()
+        QApplication.clipboard().setText(self.oauth_client_secret.text().strip())
+        self.statusBar().showMessage("已复制 OAuth 客户端密钥", 3000)
+
+    def _copy_oauth_password(self) -> None:
+        self._save_current()
+        QApplication.clipboard().setText(self.oauth_password.text().strip())
+        self.statusBar().showMessage("已复制授权口令", 3000)
+
+    def _copy_bearer_token(self) -> None:
+        self._save_current()
+        QApplication.clipboard().setText(self.bearer_token.text().strip())
+        self.statusBar().showMessage("已复制 Bearer Token", 3000)
+
+    def _refresh_current(self) -> None:
+        if self.current_profile is None:
+            return
+        self._load_profile(self.current_profile)
+
+    def _refresh_tunnel_fields(self, *_args: object) -> None:
+        tunnel_type = self._combo_value(self.tunnel_type)
+        is_frp = tunnel_type == "frp"
+        is_cloudflare = tunnel_type == "cloudflare"
+        is_cloudflare_named = is_cloudflare and self._combo_value(self.cloudflare_mode) == "named"
+        self._set_row_visible(self.cloudflare_mode_label, self.cloudflare_mode, is_cloudflare)
+        self._set_row_visible(self.public_url_label, self.public_url_edit, is_cloudflare)
+        self._set_row_visible(self.cloudflare_token_label, self.cloudflare_token_edit, is_cloudflare_named)
+        self._set_row_visible(self.frp_server_label, self.frp_server_edit, is_frp)
+        self._set_row_visible(self.subdomain_label, self.subdomain_edit, is_frp)
+        self.public_url_edit.setReadOnly(is_cloudflare and not is_cloudflare_named)
+        self.copy_frp_button.setEnabled(is_frp and self.current_profile is not None)
+        if is_cloudflare_named:
+            self.public_url_edit.setPlaceholderText("例如：https://mcp.example.com")
+        elif is_cloudflare:
+            self.public_url_edit.setPlaceholderText("Cloudflare 启动后会自动分配公网地址")
+            if self.current_profile is not None and not self.runtime.resolved_public_url(self.current_profile):
+                self.public_url_edit.setText("")
+        self._refresh_connection_view()
+
+    def _refresh_auth_fields(self, *_args: object) -> None:
+        auth_type = self._combo_value(self.auth_type)
+        is_oauth = auth_type == "oauth"
+        is_bearer = auth_type == "bearer"
+        self._set_row_visible(self.oauth_client_id_label, self.oauth_client_id, is_oauth)
+        self._set_row_visible(self.oauth_client_secret_label, self.oauth_client_secret, is_oauth)
+        self._set_row_visible(self.oauth_password_label, self.oauth_password, is_oauth)
+        self._set_row_visible(self.bearer_token_label, self.bearer_token, is_bearer)
+        self.oauth_actions.setVisible(is_oauth)
+        self.bearer_actions.setVisible(is_bearer)
+        if is_oauth:
+            self.auth_hint.setText("ChatGPT 里填写 OAuth 客户端 ID 和 OAuth 客户端密钥；首次授权时再输入授权口令。")
+        elif is_bearer:
+            self.auth_hint.setText("Bearer 模式下，把这个 Token 配给调用方即可。")
+        else:
+            self.auth_hint.setText("当前不会要求认证，适合纯本地调试，不建议直接暴露到公网。")
+        self._refresh_connection_view()
+
+    def _refresh_connection_view(self, *_args: object) -> None:
+        endpoint = self._draft_endpoint()
+        self.endpoint_label.setText(f"公网 MCP 地址：{endpoint}")
+        self.local_label.setText(f"本地 MCP 地址：http://127.0.0.1:{self.local_port.value()}/mcp")
+        self.endpoint_hint.setText(f"当前入口：{endpoint}")
+
+    def _load_logs(self, profile: WorkspaceProfile) -> None:
+        log_dir = log_dir_for_profile(profile.id)
+        output: list[str] = []
+        for name in ("cloudflared.log", "stderr.log", "stdout.log"):
+            path = log_dir / name
+            if path.exists():
+                text = path.read_text(encoding="utf-8", errors="replace")
+                output.append(f"[{name}]\n{text[-4000:]}")
+        self.log_output.setPlainText("\n\n".join(output) if output else "当前还没有日志。")
+
+    def _render_status(self, status) -> None:
+        state_map = {
+            "running": "运行中",
+            "stopped": "已停止",
+            "starting": "启动中",
+            "error": "异常",
+        }
+        state_text = state_map.get(status.state, status.state)
+        self.status_label.setText(f"{state_text}  PID={status.pid or '-'}")
+        color = "#067647" if status.state == "running" else "#b42318"
+        self.status_label.setStyleSheet(f"font-weight:700; color:{color};")
+
+    def _run_runtime_job(self, profile: WorkspaceProfile, action: str) -> None:
+        if self._runtime_thread is not None:
+            return
+        self._runtime_thread = QThread(self)
+        self._runtime_job = RuntimeJob(self.runtime, profile, action)
+        self._runtime_job.moveToThread(self._runtime_thread)
+        self._runtime_thread.started.connect(self._runtime_job.run)
+        self._runtime_job.finished.connect(self._on_runtime_job_finished)
+        self._runtime_job.finished.connect(self._runtime_thread.quit)
+        self._runtime_thread.finished.connect(self._cleanup_runtime_job)
+        self._runtime_thread.start()
+
+    def _on_runtime_job_finished(self, action: str, status: object, error_message: str) -> None:
+        profile = self.current_profile
+        self._set_runtime_busy(False)
+        if profile is None:
+            return
+        if error_message:
+            self._load_logs(profile)
+            self._refresh_workspace_item(profile.id)
+            QMessageBox.critical(self, "启动失败" if action == "start" else "停止失败", error_message)
+            return
+        if status is not None:
+            self._render_status(status)
+        self._sync_profile_runtime_view(profile)
+        self._load_logs(profile)
+        self._refresh_workspace_item(profile.id)
+
+    def _cleanup_runtime_job(self) -> None:
+        if self._runtime_job is not None:
+            self._runtime_job.deleteLater()
+            self._runtime_job = None
+        if self._runtime_thread is not None:
+            self._runtime_thread.deleteLater()
+            self._runtime_thread = None
+
+    def _set_runtime_busy(self, busy: bool, state_text: str | None = None) -> None:
+        self.start_button.setEnabled(not busy and self.current_profile is not None)
+        self.stop_button.setEnabled(not busy and self.current_profile is not None)
+        self.workspace_list.setEnabled(not busy)
+        if busy:
+            profile = self.current_profile
+            self._busy_profile_id = profile.id if profile is not None else None
+            self._busy_action = state_text
+            self._busy_dots = 0
+            self.start_button.setText("启动中..." if state_text == "启动中" else "启动")
+            self.stop_button.setText("停止中..." if state_text == "停止中" else "停止")
+            if state_text:
+                self.status_label.setText(f"{state_text}  PID=-")
+                self.status_label.setStyleSheet("font-weight:700; color:#b54708;")
+            self.statusBar().showMessage(f"{state_text}，请稍候...", 0)
+            if not self._busy_timer.isActive():
+                self._busy_timer.start()
+            if self._busy_profile_id:
+                self._refresh_workspace_item(self._busy_profile_id)
+            return
+        self._busy_timer.stop()
+        self._busy_profile_id = None
+        self._busy_action = None
+        self._busy_dots = 0
+        self.start_button.setText("启动")
+        self.stop_button.setText("停止")
+        self.statusBar().clearMessage()
+
+    def _tick_busy_indicator(self) -> None:
+        if self._busy_action is None:
+            return
+        self._busy_dots = (self._busy_dots + 1) % 4
+        dots = "." * self._busy_dots
+        label = f"{self._busy_action}{dots}"
+        self.status_label.setText(f"{label}  PID=-")
+        self.status_label.setStyleSheet("font-weight:700; color:#b54708;")
+        if self._busy_profile_id:
+            self._refresh_workspace_item(self._busy_profile_id)
+
+    def _sync_profile_runtime_view(self, profile: WorkspaceProfile) -> None:
+        if profile.tunnel.type == "cloudflare":
+            public_url = self.runtime.resolved_public_url(profile)
+            if public_url:
+                self.public_url_edit.setText(public_url)
+            elif profile.tunnel.cloudflare_mode != "named":
+                self.public_url_edit.clear()
+        self._refresh_connection_view()
+
+    def _refresh_workspace_item(self, profile_id: str) -> None:
+        for index, profile in enumerate(self.profiles):
+            if profile.id != profile_id:
+                continue
+            item = self.workspace_list.item(index)
+            if item is not None:
+                item.setText(self._workspace_summary(profile))
+            break
+
+    def _draft_public_url(self) -> str:
+        tunnel_type = self._combo_value(self.tunnel_type)
+        if tunnel_type == "frp":
+            subdomain = self.subdomain_edit.text().strip()
+            server = self.frp_server_edit.text().strip()
+            if subdomain and server:
+                return f"https://{subdomain}.{server}"
+        if tunnel_type == "cloudflare":
+            if self.current_profile is not None:
+                resolved = self.runtime.resolved_public_url(self.current_profile)
+                if resolved:
+                    return resolved
+            if self._combo_value(self.cloudflare_mode) == "named":
+                return self.public_url_edit.text().strip().rstrip("/")
+            return ""
+        return self.public_url_edit.text().strip().rstrip("/")
+
+    def _draft_endpoint(self) -> str:
+        base_url = self._draft_public_url().rstrip("/")
+        if not base_url:
+            return "-"
+        return f"{base_url}/mcp"
+
+    def _workspace_summary(self, profile: WorkspaceProfile) -> str:
+        state = self._workspace_state(profile)
+        endpoint = self._profile_endpoint_summary(profile)
+        state_map = {
+            "running": "运行中",
+            "stopped": "已停止",
+            "starting": "启动中",
+            "error": "异常",
+            "stopping": "停止中",
+        }
+        return "\n".join(
+            [
+                profile.name,
+                profile.path,
+                f"隧道：{self._label_for_value(self.TUNNEL_OPTIONS, profile.tunnel.type)}  认证：{self._label_for_value(self.AUTH_OPTIONS, profile.auth.type)}",
+                f"状态：{state_map.get(state, state)}  地址：{endpoint or '-'}",
+            ]
+        )
+
+    def _restore_selection(self, profile_id: str) -> None:
+        for index, profile in enumerate(self.profiles):
+            if profile.id == profile_id:
+                self.workspace_list.setCurrentRow(index)
+                return
+
+    def _require_profile(self) -> WorkspaceProfile:
+        if self.current_profile is None:
+            raise RuntimeError("当前没有选中工作区。")
+        return self.current_profile
+
+    def _fill_combo(self, combo: QComboBox, options: list[tuple[str, str]]) -> None:
+        for value, label in options:
+            combo.addItem(label, value)
+
+    def _combo_value(self, combo: QComboBox) -> str:
+        return str(combo.currentData())
+
+    def _set_combo_value(self, combo: QComboBox, value: str) -> None:
+        index = combo.findData(value)
+        if index >= 0:
+            combo.setCurrentIndex(index)
+
+    def _label_for_value(self, options: list[tuple[str, str]], value: str) -> str:
+        for item_value, item_label in options:
+            if item_value == value:
+                return item_label
+        return value
+
+    def _set_row_visible(self, label: QLabel, field: QWidget, visible: bool) -> None:
+        label.setVisible(visible)
+        field.setVisible(visible)
+
+    def _profile_public_url_for_edit(self, profile: WorkspaceProfile) -> str:
+        if profile.tunnel.type == "frp":
+            return profile.tunnel.public_url
+        resolved = self.runtime.resolved_public_url(profile)
+        if resolved:
+            return resolved
+        if profile.tunnel.cloudflare_mode == "named":
+            return profile.tunnel.public_url
+        return ""
+
+    def _profile_endpoint_summary(self, profile: WorkspaceProfile) -> str:
+        endpoint = self.runtime.resolved_endpoint(profile)
+        if endpoint:
+            return endpoint
+        if profile.tunnel.type == "frp":
+            return profile.endpoint
+        if profile.tunnel.type == "cloudflare" and profile.tunnel.cloudflare_mode == "named" and profile.tunnel.public_url.strip():
+            return f"{profile.tunnel.public_url.rstrip('/')}/mcp"
+        return "-"
+
+    def _workspace_state(self, profile: WorkspaceProfile) -> str:
+        if self._busy_profile_id == profile.id and self._busy_action == "启动中":
+            return "starting"
+        if self._busy_profile_id == profile.id and self._busy_action == "停止中":
+            return "stopping"
+        return self.runtime.summary_state(profile)
+
+
+def main() -> int:
+    app = QApplication(sys.argv)
+    app.setStyleSheet(STYLESHEET)
+    window = MainWindow()
+    window.show()
+
+    def _present_window() -> None:
+        screen = app.primaryScreen()
+        if screen is not None:
+            available = screen.availableGeometry()
+            frame = window.frameGeometry()
+            frame.moveCenter(available.center())
+            window.move(frame.topLeft())
+        window.setWindowState((window.windowState() & ~Qt.WindowState.WindowMinimized) | Qt.WindowState.WindowActive)
+        window.raise_()
+        window.activateWindow()
+
+    QTimer.singleShot(0, _present_window)
+    return app.exec()

--- a/apps/desktop-client/mcp_desktop_client/health.py
+++ b/apps/desktop-client/mcp_desktop_client/health.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+from .models import WorkspaceProfile
+
+
+@dataclass
+class HealthItem:
+    label: str
+    ok: bool
+    detail: str
+
+
+def _check_url(url: str) -> tuple[bool, str]:
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=4) as response:
+            return True, f"HTTP {response.status}"
+    except urllib.error.HTTPError as exc:
+        if exc.code in {200, 401, 404}:
+            return True, f"HTTP {exc.code}"
+        return False, f"HTTP {exc.code}"
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+def _check_json_field(url: str, field: str) -> tuple[bool, str]:
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=4) as response:
+            payload = json.loads(response.read().decode("utf-8", errors="replace"))
+            value = payload.get(field)
+            if isinstance(value, list):
+                value = " / ".join(str(item) for item in value)
+            return True, f"HTTP {response.status}; {field}={value}"
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code}"
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+def run_health_checks(profile: WorkspaceProfile) -> list[HealthItem]:
+    local_ok, local_detail = _check_url(profile.local_endpoint)
+    oauth_ok, oauth_detail = _check_json_field(
+        f"{profile.effective_public_url}/.well-known/oauth-authorization-server",
+        "token_endpoint_auth_methods_supported",
+    )
+    public_ok, public_detail = _check_url(profile.endpoint)
+    protected_ok, protected_detail = _check_json_field(
+        f"{profile.effective_public_url}/.well-known/oauth-protected-resource",
+        "authorization_servers",
+    )
+    return [
+        HealthItem("本地 /mcp", local_ok, local_detail),
+        HealthItem("公网 /mcp", public_ok, public_detail),
+        HealthItem("OAuth 授权元数据", oauth_ok, oauth_detail),
+        HealthItem("OAuth 受保护资源元数据", protected_ok, protected_detail),
+    ]
+
+
+def summarize_health(items: list[HealthItem]) -> str:
+    summary = {"checks": [{"label": item.label, "ok": item.ok, "detail": item.detail} for item in items]}
+    return json.dumps(summary, indent=2, ensure_ascii=False)

--- a/apps/desktop-client/mcp_desktop_client/models.py
+++ b/apps/desktop-client/mcp_desktop_client/models.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+from uuid import uuid4
+
+
+def _new_secret() -> str:
+    return uuid4().hex + uuid4().hex
+
+
+def _new_client_id() -> str:
+    return f"chatgpt-client-{uuid4().hex[:12]}"
+
+
+@dataclass
+class TunnelConfig:
+    type: str = "frp"
+    public_url: str = ""
+    frp_server: str = ""
+    frp_subdomain: str = ""
+    cloudflare_mode: str = "quick"
+    cloudflare_token: str = ""
+
+    def computed_public_url(self) -> str:
+        if self.type == "frp" and self.frp_server and self.frp_subdomain:
+            return f"https://{self.frp_subdomain}.{self.frp_server}"
+        return self.public_url
+
+
+@dataclass
+class AuthConfig:
+    type: str = "oauth"
+    oauth_client_id: str = field(default_factory=_new_client_id)
+    oauth_client_secret: str = field(default_factory=_new_secret)
+    oauth_password: str = field(default_factory=_new_secret)
+    oauth_token_secret: str = field(default_factory=_new_secret)
+    bearer_token: str = field(default_factory=_new_secret)
+
+
+@dataclass
+class RuntimeConfig:
+    local_port: int = 28766
+    tool_profile: str = "full"
+    permission_mode: str = "trusted"
+    runtime_command: str = ""
+
+
+@dataclass
+class WorkspaceProfile:
+    id: str
+    name: str
+    path: str
+    tunnel: TunnelConfig = field(default_factory=TunnelConfig)
+    auth: AuthConfig = field(default_factory=AuthConfig)
+    runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
+
+    @property
+    def endpoint(self) -> str:
+        return f"{self.effective_public_url.rstrip('/')}/mcp"
+
+    @property
+    def local_endpoint(self) -> str:
+        return f"http://127.0.0.1:{self.runtime.local_port}/mcp"
+
+    @property
+    def effective_public_url(self) -> str:
+        return self.tunnel.computed_public_url().rstrip("/")
+
+    def frp_proxy_snippet(self) -> str:
+        return "\n".join(
+            [
+                "[[proxies]]",
+                f'name = "{self.name.lower().replace(" ", "-") or "workspace"}-mcp"',
+                'type = "http"',
+                'localIP = "host.docker.internal"',
+                f"localPort = {self.runtime.local_port}",
+                f'subdomain = "{self.tunnel.frp_subdomain}"',
+            ]
+        )
+
+    def to_record(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_record(cls, record: dict[str, Any]) -> "WorkspaceProfile":
+        return cls(
+            id=record["id"],
+            name=record["name"],
+            path=record["path"],
+            tunnel=TunnelConfig(**record.get("tunnel", {})),
+            auth=AuthConfig(**record.get("auth", {})),
+            runtime=RuntimeConfig(**record.get("runtime", {})),
+        )
+
+
+@dataclass
+class RuntimeStatus:
+    state: str = "stopped"
+    pid: int | None = None
+    local_message: str = "未启动"
+    public_message: str = "未知"
+
+
+def build_profile(path: str, name: str | None = None) -> WorkspaceProfile:
+    cleaned = path.rstrip("\\/")
+    label = name or cleaned.replace("\\", "/").split("/")[-1]
+    return WorkspaceProfile(id=uuid4().hex, name=label or "工作区", path=cleaned)

--- a/apps/desktop-client/mcp_desktop_client/runtime.py
+++ b/apps/desktop-client/mcp_desktop_client/runtime.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import psutil
+
+from .models import RuntimeStatus, WorkspaceProfile
+from .storage import log_dir_for_profile, runtime_state_file_for_profile
+
+TRYCLOUDFLARE_URL_RE = re.compile(r"https://[a-z0-9-]+\.trycloudflare\.com", re.I)
+
+
+@dataclass
+class ManagedSession:
+    runtime_process: subprocess.Popen[str] | None = None
+    tunnel_process: subprocess.Popen[str] | None = None
+    runtime_pid: int | None = None
+
+
+class RuntimeManager:
+    RUNTIME_START_TIMEOUT_SECONDS = 20.0
+    PORT_RELEASE_TIMEOUT_SECONDS = 8.0
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, ManagedSession] = {}
+
+    def start(self, profile: WorkspaceProfile) -> RuntimeStatus:
+        try:
+            self._validate_tunnel_requirements(profile)
+        except Exception as exc:
+            self._append_tunnel_error_log(profile, str(exc))
+            raise
+        self._cleanup_orphan_tunnel(profile)
+        existing_pid = self._find_runtime_pid(profile)
+        if existing_pid is not None:
+            if profile.tunnel.type == "cloudflare" and self._find_tunnel_pid(profile) is None:
+                try:
+                    tunnel_process, public_url = self._start_cloudflare_tunnel(profile)
+                except Exception as exc:
+                    self._append_tunnel_error_log(profile, str(exc))
+                    raise
+                self._sessions[profile.id] = ManagedSession(
+                    runtime_process=None,
+                    tunnel_process=tunnel_process,
+                    runtime_pid=existing_pid,
+                )
+                self._write_runtime_state(
+                    profile,
+                    runtime_pid=existing_pid,
+                    tunnel_pid=tunnel_process.pid,
+                    public_url=public_url,
+                )
+            return self.status(profile)
+
+        conflicting_pid = self._find_pid_by_port(profile.runtime.local_port)
+        if conflicting_pid is not None:
+            conflict_command = self._command_line_for_pid(conflicting_pid)
+            raise RuntimeError(
+                "本地端口已被占用，无法启动。\n"
+                f"端口：{profile.runtime.local_port}\n"
+                f"占用进程 PID：{conflicting_pid}\n"
+                f"命令行：{conflict_command or '未知'}"
+            )
+
+        runtime_process, runtime_pid = self._start_runtime_process(profile)
+        tunnel_process: subprocess.Popen[str] | None = None
+        public_url = self._server_url_for_profile(profile) if profile.tunnel.type == "frp" else ""
+
+        try:
+            if profile.tunnel.type == "cloudflare":
+                tunnel_process, public_url = self._start_cloudflare_tunnel(profile)
+            elif profile.tunnel.type != "frp":
+                raise RuntimeError("当前仅支持 FRP 和 Cloudflare。")
+        except Exception as exc:
+            self._append_tunnel_error_log(profile, str(exc))
+            self._terminate_process_tree(runtime_pid)
+            if runtime_process.pid != runtime_pid:
+                self._terminate_process_tree(runtime_process.pid)
+            self._clear_runtime_state(profile.id)
+            raise
+
+        self._sessions[profile.id] = ManagedSession(
+            runtime_process=runtime_process,
+            tunnel_process=tunnel_process,
+            runtime_pid=runtime_pid,
+        )
+        self._write_runtime_state(
+            profile,
+            runtime_pid=runtime_pid,
+            tunnel_pid=tunnel_process.pid if tunnel_process else None,
+            public_url=public_url,
+        )
+        return self.status(profile)
+
+    def stop(self, profile: WorkspaceProfile) -> RuntimeStatus:
+        session = self._sessions.pop(profile.id, None)
+        state = self._read_runtime_state(profile.id)
+
+        tunnel_pid: int | None = None
+        runtime_pid: int | None = None
+        if session is not None:
+            if session.tunnel_process and session.tunnel_process.poll() is None:
+                tunnel_pid = session.tunnel_process.pid
+            if session.runtime_pid is not None:
+                runtime_pid = session.runtime_pid
+            elif session.runtime_process and session.runtime_process.poll() is None:
+                runtime_pid = session.runtime_process.pid
+        if tunnel_pid is None and isinstance(state.get("tunnel_pid"), int):
+            tunnel_pid = state["tunnel_pid"]
+        if runtime_pid is None and isinstance(state.get("runtime_pid"), int):
+            runtime_pid = state["runtime_pid"]
+        if runtime_pid is None and isinstance(state.get("pid"), int):
+            runtime_pid = state["pid"]
+        if tunnel_pid is None:
+            tunnel_pid = self._find_tunnel_pid(profile)
+        if runtime_pid is None:
+            runtime_pid = self._find_runtime_pid(profile)
+
+        if tunnel_pid is not None:
+            self._terminate_process_tree(tunnel_pid)
+        if runtime_pid is not None:
+            self._terminate_process_tree(runtime_pid)
+        if session is not None and session.runtime_process and session.runtime_process.poll() is None:
+            if runtime_pid != session.runtime_process.pid:
+                self._terminate_process_tree(session.runtime_process.pid)
+        self._wait_for_port_state(profile.runtime.local_port, listening=False, timeout=self.PORT_RELEASE_TIMEOUT_SECONDS)
+
+        self._clear_runtime_state(profile.id)
+        return RuntimeStatus(state="stopped", local_message="已停止", public_message="已停止")
+
+    def status(self, profile: WorkspaceProfile) -> RuntimeStatus:
+        runtime_pid = self._find_runtime_pid(profile)
+        tunnel_pid = self._find_tunnel_pid(profile)
+        public_url = self.resolved_public_url(profile)
+
+        if runtime_pid is None:
+            if tunnel_pid is not None:
+                self._terminate_process_tree(tunnel_pid)
+            self._clear_runtime_state(profile.id)
+            return RuntimeStatus(state="stopped", local_message="当前未运行", public_message="未知")
+
+        if profile.tunnel.type == "cloudflare" and tunnel_pid is None:
+            return RuntimeStatus(
+                state="error",
+                pid=runtime_pid,
+                local_message=f"本地 MCP 正在监听 127.0.0.1:{profile.runtime.local_port}",
+                public_message="Cloudflare 隧道未建立",
+            )
+
+        public_message = public_url or profile.endpoint
+        if profile.tunnel.type == "cloudflare" and not public_url:
+            public_message = "等待 Cloudflare 分配公网地址"
+        return RuntimeStatus(
+            state="running",
+            pid=runtime_pid,
+            local_message=f"正在监听 127.0.0.1:{profile.runtime.local_port}",
+            public_message=public_message,
+        )
+
+    def summary_state(self, profile: WorkspaceProfile) -> str:
+        return self.status(profile).state
+
+    def resolved_public_url(self, profile: WorkspaceProfile) -> str:
+        if profile.tunnel.type == "frp":
+            return profile.effective_public_url
+        if profile.tunnel.type == "cloudflare" and profile.tunnel.cloudflare_mode == "named":
+            return profile.tunnel.public_url.rstrip("/")
+        state = self._read_runtime_state(profile.id)
+        value = state.get("public_url")
+        return str(value).rstrip("/") if isinstance(value, str) and value.strip() else ""
+
+    def resolved_endpoint(self, profile: WorkspaceProfile) -> str:
+        public_url = self.resolved_public_url(profile)
+        if not public_url:
+            return ""
+        return f"{public_url.rstrip('/')}/mcp"
+
+    def _start_runtime_process(self, profile: WorkspaceProfile) -> tuple[subprocess.Popen[str], int]:
+        command = self._resolve_command(profile)
+        env = os.environ.copy()
+        server_url = self._server_url_for_profile(profile)
+        if server_url:
+            env["CODING_TOOLS_MCP_SERVER_URL"] = server_url
+        self._configure_pythonpath_for_local_repo(command, env)
+        args = command + self._runtime_args(profile, env)
+
+        log_dir = log_dir_for_profile(profile.id)
+        stdout_path = log_dir / "stdout.log"
+        stderr_path = log_dir / "stderr.log"
+        stdout_handle = stdout_path.open("w", encoding="utf-8")
+        stderr_handle = stderr_path.open("w", encoding="utf-8")
+        popen_kwargs: dict[str, object] = {
+            "args": args,
+            "cwd": profile.path,
+            "env": env,
+            "stdout": stdout_handle,
+            "stderr": stderr_handle,
+            "text": True,
+        }
+        if os.name == "nt":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_kwargs["start_new_session"] = True
+        process = subprocess.Popen(**popen_kwargs)
+        if not self._wait_for_port_state(
+            profile.runtime.local_port,
+            listening=True,
+            timeout=self.RUNTIME_START_TIMEOUT_SECONDS,
+        ):
+            self._terminate_process_tree(process.pid)
+            raise RuntimeError(f"MCP 运行时没有在预期时间内监听端口 {profile.runtime.local_port}。")
+        runtime_pid = self._find_pid_by_port(profile.runtime.local_port)
+        if runtime_pid is None:
+            self._terminate_process_tree(process.pid)
+            raise RuntimeError(f"MCP 运行时已经启动，但未识别到端口 {profile.runtime.local_port} 对应的进程。")
+        return process, runtime_pid
+
+    def _start_cloudflare_tunnel(self, profile: WorkspaceProfile) -> tuple[subprocess.Popen[str], str]:
+        cloudflared = self._find_cloudflared_command()
+        if not cloudflared:
+            raise RuntimeError("未找到 cloudflared。请先安装 Cloudflare Tunnel CLI，再使用 Cloudflare 方式。")
+
+        log_dir = log_dir_for_profile(profile.id)
+        tunnel_log = log_dir / "cloudflared.log"
+        if profile.tunnel.cloudflare_mode == "named":
+            if not profile.tunnel.cloudflare_token.strip():
+                raise RuntimeError("Cloudflare 命名隧道模式需要填写 Tunnel Token。")
+            if not profile.tunnel.public_url.strip():
+                raise RuntimeError("Cloudflare 命名隧道模式需要填写固定公网地址。")
+            args = [cloudflared, "tunnel", "run", "--token", profile.tunnel.cloudflare_token.strip()]
+        else:
+            args = [cloudflared, "tunnel", "--url", f"http://127.0.0.1:{profile.runtime.local_port}"]
+        popen_kwargs: dict[str, object] = {
+            "args": args,
+            "cwd": profile.path,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.STDOUT,
+            "text": True,
+            "encoding": "utf-8",
+            "errors": "replace",
+        }
+        if os.name == "nt":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_kwargs["start_new_session"] = True
+        process = subprocess.Popen(**popen_kwargs)
+        public_url_holder: dict[str, str] = {"value": ""}
+        ready = threading.Event()
+        thread = threading.Thread(
+            target=self._stream_cloudflare_output,
+            args=(profile, process, tunnel_log, public_url_holder, ready),
+            daemon=True,
+        )
+        thread.start()
+        ready.wait(timeout=12)
+        if profile.tunnel.cloudflare_mode == "named":
+            return process, profile.tunnel.public_url.rstrip("/")
+        if not public_url_holder["value"]:
+            raise RuntimeError("cloudflared 已启动，但在预期时间内没有返回 trycloudflare.com 公网地址。")
+        return process, public_url_holder["value"]
+
+    def _stream_cloudflare_output(
+        self,
+        profile: WorkspaceProfile,
+        process: subprocess.Popen[str],
+        log_path: Path,
+        public_url_holder: dict[str, str],
+        ready: threading.Event,
+    ) -> None:
+        stream = process.stdout
+        if stream is None:
+            ready.set()
+            return
+
+        with log_path.open("a", encoding="utf-8") as handle:
+            for raw_line in stream:
+                line = raw_line.rstrip("\n")
+                handle.write(raw_line)
+                handle.flush()
+                if profile.tunnel.cloudflare_mode == "named":
+                    lowered = line.lower()
+                    if "registered tunnel connection" in lowered or "starting metrics server" in lowered:
+                        ready.set()
+                    continue
+                if not public_url_holder["value"]:
+                    matched = TRYCLOUDFLARE_URL_RE.search(line)
+                    if matched:
+                        public_url_holder["value"] = matched.group(0).rstrip("/")
+                        self._update_runtime_state(profile.id, public_url=public_url_holder["value"])
+                        ready.set()
+            ready.set()
+
+    def _server_url_for_profile(self, profile: WorkspaceProfile) -> str:
+        if profile.tunnel.type == "frp":
+            return profile.effective_public_url
+        if profile.tunnel.type == "cloudflare" and profile.tunnel.cloudflare_mode == "named":
+            return profile.tunnel.public_url.rstrip("/")
+        return ""
+
+    def _validate_tunnel_requirements(self, profile: WorkspaceProfile) -> None:
+        if profile.tunnel.type == "frp":
+            return
+        if profile.tunnel.type != "cloudflare":
+            raise RuntimeError("当前仅支持 FRP 和 Cloudflare。")
+        if not self._find_cloudflared_command():
+            raise RuntimeError(
+                "未找到 cloudflared。请先安装 Cloudflare Tunnel CLI。\n"
+                "Windows 可执行：winget install Cloudflare.cloudflared"
+            )
+        if profile.tunnel.cloudflare_mode == "named":
+            if not profile.tunnel.cloudflare_token.strip():
+                raise RuntimeError("Cloudflare 固定域名模式需要填写 Tunnel Token。")
+            if not profile.tunnel.public_url.strip():
+                raise RuntimeError("Cloudflare 固定域名模式需要填写公网地址。")
+
+    def _append_tunnel_error_log(self, profile: WorkspaceProfile, message: str) -> None:
+        path = log_dir_for_profile(profile.id) / "cloudflared.log"
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(f"[{timestamp}] {message}\n")
+
+    def _resolve_command(self, profile: WorkspaceProfile) -> list[str]:
+        if profile.runtime.runtime_command.strip():
+            return profile.runtime.runtime_command.strip().split()
+        if shutil.which("coding-tools-mcp"):
+            return ["coding-tools-mcp"]
+        if shutil.which("uvx"):
+            return ["uvx", "coding-tools-mcp"]
+
+        repo_root = Path(__file__).resolve().parents[4]
+        if (repo_root / "coding_tools_mcp").exists():
+            return [sys.executable, "-m", "coding_tools_mcp"]
+        raise RuntimeError("未找到 uvx、coding-tools-mcp，或本地模块入口。")
+
+    def _runtime_args(self, profile: WorkspaceProfile, env: dict[str, str]) -> list[str]:
+        args = [
+            "--workspace",
+            profile.path,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(profile.runtime.local_port),
+            "--tool-profile",
+            profile.runtime.tool_profile,
+            "--permission-mode",
+            profile.runtime.permission_mode,
+        ]
+        if profile.auth.type == "oauth":
+            env["CODING_TOOLS_MCP_OAUTH_CLIENT_ID"] = profile.auth.oauth_client_id
+            if profile.auth.oauth_client_secret.strip():
+                env["CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET"] = profile.auth.oauth_client_secret
+            else:
+                env.pop("CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET", None)
+            env["CODING_TOOLS_MCP_OAUTH_PASSWORD"] = profile.auth.oauth_password
+            env["CODING_TOOLS_MCP_OAUTH_TOKEN_SECRET"] = profile.auth.oauth_token_secret
+            args.append("--oauth-mode")
+        elif profile.auth.type == "bearer":
+            args.extend(["--auth-token", profile.auth.bearer_token])
+        elif profile.auth.type == "noauth":
+            env["CODING_TOOLS_MCP_AUTH_MODE"] = "noauth"
+        return args
+
+    def _configure_pythonpath_for_local_repo(self, command: list[str], env: dict[str, str]) -> None:
+        if command[:2] != [sys.executable, "-m"]:
+            return
+        repo_root = str(Path(__file__).resolve().parents[4])
+        current = env.get("PYTHONPATH", "").strip()
+        env["PYTHONPATH"] = repo_root if not current else os.pathsep.join([repo_root, current])
+
+    def _state_file(self, profile_id: str) -> Path:
+        return runtime_state_file_for_profile(profile_id)
+
+    def _write_runtime_state(
+        self,
+        profile: WorkspaceProfile,
+        *,
+        runtime_pid: int | None,
+        tunnel_pid: int | None = None,
+        public_url: str = "",
+    ) -> None:
+        payload = {
+            "runtime_pid": runtime_pid,
+            "tunnel_pid": tunnel_pid,
+            "port": profile.runtime.local_port,
+            "workspace": profile.path,
+            "tunnel_type": profile.tunnel.type,
+            "public_url": public_url.rstrip("/"),
+        }
+        self._state_file(profile.id).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    def _update_runtime_state(self, profile_id: str, **updates: object) -> None:
+        state = self._read_runtime_state(profile_id)
+        if not state:
+            return
+        state.update(updates)
+        self._state_file(profile_id).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+    def _clear_runtime_state(self, profile_id: str) -> None:
+        path = self._state_file(profile_id)
+        if path.exists():
+            path.unlink()
+
+    def _read_runtime_state(self, profile_id: str) -> dict[str, object]:
+        path = self._state_file(profile_id)
+        if not path.exists():
+            return {}
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return {}
+
+    def _find_runtime_pid(self, profile: WorkspaceProfile) -> int | None:
+        session = self._sessions.get(profile.id)
+        if session and session.runtime_pid is not None and self._process_matches_profile(session.runtime_pid, profile):
+            return session.runtime_pid
+        if session and session.runtime_process and session.runtime_process.poll() is None:
+            process_pid = session.runtime_process.pid
+            if self._process_matches_profile(process_pid, profile):
+                return process_pid
+        port_pid = self._find_pid_by_port(profile.runtime.local_port)
+        if port_pid is not None and self._process_matches_profile(port_pid, profile):
+            return port_pid
+        state = self._read_runtime_state(profile.id)
+        runtime_pid = state.get("runtime_pid", state.get("pid"))
+        if isinstance(runtime_pid, int) and self._process_matches_profile(runtime_pid, profile):
+            return runtime_pid
+        return None
+
+    def _find_tunnel_pid(self, profile: WorkspaceProfile) -> int | None:
+        session = self._sessions.get(profile.id)
+        if session and session.tunnel_process and session.tunnel_process.poll() is None:
+            return session.tunnel_process.pid
+        state = self._read_runtime_state(profile.id)
+        tunnel_pid = state.get("tunnel_pid")
+        if isinstance(tunnel_pid, int) and self._process_is_alive(tunnel_pid):
+            return tunnel_pid
+        if profile.tunnel.type == "cloudflare" and profile.tunnel.cloudflare_mode == "quick":
+            return self._find_cloudflare_quick_tunnel_pid(profile.runtime.local_port)
+        return None
+
+    def _process_matches_profile(self, pid: int, profile: WorkspaceProfile) -> bool:
+        command_line = self._command_line_for_pid(pid)
+        if not command_line:
+            return False
+        normalized_command = command_line.replace("\\", "/").lower()
+        normalized_workspace = profile.path.replace("\\", "/").lower()
+        return (
+            "coding-tools-mcp" in normalized_command
+            and f"--port {profile.runtime.local_port}" in normalized_command
+            and normalized_workspace in normalized_command
+        )
+
+    def _process_is_alive(self, pid: int) -> bool:
+        return self._safe_process(pid) is not None
+
+    def _find_pid_by_port(self, port: int) -> int | None:
+        try:
+            for connection in psutil.net_connections(kind="tcp"):
+                if connection.status != psutil.CONN_LISTEN:
+                    continue
+                if not connection.laddr or connection.laddr.port != port:
+                    continue
+                if connection.pid:
+                    return connection.pid
+        except (psutil.AccessDenied, psutil.Error):
+            return None
+        return None
+
+    def _wait_for_port_state(self, port: int, listening: bool, timeout: float) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            is_listening = self._find_pid_by_port(port) is not None
+            if is_listening == listening:
+                return True
+            time.sleep(0.2)
+        return False
+
+    def _command_line_for_pid(self, pid: int) -> str:
+        process = self._safe_process(pid)
+        if process is None:
+            return ""
+        try:
+            return " ".join(process.cmdline()).strip()
+        except (psutil.AccessDenied, psutil.Error):
+            return ""
+
+    def _terminate_process_tree(self, pid: int) -> None:
+        try:
+            process = psutil.Process(pid)
+        except psutil.Error:
+            return
+
+        try:
+            children = process.children(recursive=True)
+        except (psutil.AccessDenied, psutil.Error):
+            children = []
+
+        for child in reversed(children):
+            try:
+                child.terminate()
+            except psutil.Error:
+                continue
+        try:
+            process.terminate()
+        except psutil.Error:
+            pass
+
+        _gone, alive = psutil.wait_procs(children + [process], timeout=3)
+        if alive:
+            for item in alive:
+                try:
+                    item.kill()
+                except psutil.Error:
+                    continue
+            psutil.wait_procs(alive, timeout=2)
+
+    def _safe_process(self, pid: int) -> psutil.Process | None:
+        try:
+            return psutil.Process(pid)
+        except psutil.Error:
+            return None
+
+    def _cleanup_orphan_tunnel(self, profile: WorkspaceProfile) -> None:
+        if self._find_runtime_pid(profile) is not None:
+            return
+        tunnel_pid = self._find_tunnel_pid(profile)
+        if tunnel_pid is None:
+            return
+        self._terminate_process_tree(tunnel_pid)
+        self._clear_runtime_state(profile.id)
+
+    def _find_cloudflare_quick_tunnel_pid(self, port: int) -> int | None:
+        target = f"http://127.0.0.1:{port}".lower()
+        for process in psutil.process_iter(["pid", "name", "cmdline"]):
+            try:
+                command_line = " ".join(process.info.get("cmdline") or []).lower()
+            except (psutil.AccessDenied, psutil.Error):
+                continue
+            if "cloudflared" not in command_line:
+                continue
+            if target in command_line:
+                return process.info["pid"]
+        return None
+
+    def _find_cloudflared_command(self) -> str | None:
+        direct = shutil.which("cloudflared")
+        if direct:
+            return direct
+        candidates = [
+            Path(r"C:\Program Files\cloudflared\cloudflared.exe"),
+            Path(r"C:\Program Files (x86)\cloudflared\cloudflared.exe"),
+            Path.home() / ".cloudflared" / "cloudflared.exe",
+        ]
+        for candidate in candidates:
+            if candidate.exists():
+                return str(candidate)
+        return None

--- a/apps/desktop-client/mcp_desktop_client/storage.py
+++ b/apps/desktop-client/mcp_desktop_client/storage.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .models import WorkspaceProfile
+
+
+APP_HOME = Path.home() / ".coding-tools-mcp-desktop"
+PROFILES_FILE = APP_HOME / "profiles.json"
+SECRETS_FILE = APP_HOME / "secrets.json"
+STATE_DIR = APP_HOME / "state"
+
+
+def ensure_storage() -> None:
+    APP_HOME.mkdir(parents=True, exist_ok=True)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_profiles() -> list[WorkspaceProfile]:
+    ensure_storage()
+    if not PROFILES_FILE.exists():
+        return []
+    data = json.loads(PROFILES_FILE.read_text(encoding="utf-8"))
+    profiles = [WorkspaceProfile.from_record(item) for item in data.get("profiles", [])]
+    secrets = json.loads(SECRETS_FILE.read_text(encoding="utf-8")) if SECRETS_FILE.exists() else {}
+    for profile in profiles:
+        if profile.id in secrets:
+            secret = secrets[profile.id]
+            profile.tunnel.cloudflare_token = secret.get("cloudflare_token", profile.tunnel.cloudflare_token)
+            profile.auth.oauth_client_secret = secret.get("oauth_client_secret", profile.auth.oauth_client_secret)
+            profile.auth.oauth_password = secret.get("oauth_password", profile.auth.oauth_password)
+            profile.auth.oauth_token_secret = secret.get("oauth_token_secret", profile.auth.oauth_token_secret)
+            profile.auth.bearer_token = secret.get("bearer_token", profile.auth.bearer_token)
+    return profiles
+
+
+def save_profiles(profiles: list[WorkspaceProfile]) -> None:
+    ensure_storage()
+    public_records = []
+    secret_records: dict[str, dict[str, str]] = {}
+    for profile in profiles:
+        record = profile.to_record()
+        record["tunnel"]["cloudflare_token"] = ""
+        record["auth"]["oauth_client_secret"] = ""
+        record["auth"]["oauth_password"] = ""
+        record["auth"]["oauth_token_secret"] = ""
+        record["auth"]["bearer_token"] = ""
+        public_records.append(record)
+        secret_records[profile.id] = {
+            "cloudflare_token": profile.tunnel.cloudflare_token,
+            "oauth_client_secret": profile.auth.oauth_client_secret,
+            "oauth_password": profile.auth.oauth_password,
+            "oauth_token_secret": profile.auth.oauth_token_secret,
+            "bearer_token": profile.auth.bearer_token,
+        }
+
+    PROFILES_FILE.write_text(json.dumps({"profiles": public_records}, indent=2) + "\n", encoding="utf-8")
+    SECRETS_FILE.write_text(json.dumps(secret_records, indent=2) + "\n", encoding="utf-8")
+
+
+def log_dir_for_profile(profile_id: str) -> Path:
+    ensure_storage()
+    target = STATE_DIR / profile_id
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def runtime_state_file_for_profile(profile_id: str) -> Path:
+    return log_dir_for_profile(profile_id) / "runtime.json"

--- a/apps/desktop-client/mcp_desktop_client/theme.py
+++ b/apps/desktop-client/mcp_desktop_client/theme.py
@@ -1,0 +1,95 @@
+STYLESHEET = """
+QWidget {
+  background: #f3f4f8;
+  color: #18212f;
+  font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei";
+  font-size: 13px;
+}
+
+QMainWindow {
+  background: #eef1f7;
+}
+
+QFrame#Sidebar,
+QFrame#Panel {
+  background: #fbfcfe;
+  border: 1px solid #dde3ee;
+  border-radius: 18px;
+}
+
+QLabel#Title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #101828;
+}
+
+QLabel#Eyebrow {
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: #6b7280;
+  text-transform: uppercase;
+}
+
+QPushButton {
+  background: #111827;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-weight: 600;
+}
+
+QPushButton:hover {
+  background: #1f2937;
+}
+
+QPushButton[secondary="true"] {
+  background: #e8edf5;
+  color: #1f2937;
+}
+
+QPushButton[secondary="true"]:hover {
+  background: #dce4f0;
+}
+
+QLineEdit, QTextEdit, QComboBox, QSpinBox {
+  background: white;
+  border: 1px solid #d7deea;
+  border-radius: 10px;
+  padding: 8px 10px;
+}
+
+QListWidget {
+  background: transparent;
+  border: none;
+}
+
+QListWidget::item {
+  background: white;
+  border: 1px solid #d7deea;
+  border-radius: 14px;
+  margin: 0 0 10px 0;
+  padding: 12px;
+}
+
+QListWidget::item:selected {
+  background: #e9efff;
+  border: 1px solid #9db6ff;
+  color: #0f172a;
+}
+
+QGroupBox {
+  font-weight: 700;
+  border: 1px solid #dde3ee;
+  border-radius: 14px;
+  margin-top: 12px;
+  padding-top: 14px;
+  background: #ffffff;
+}
+
+QGroupBox::title {
+  subcontrol-origin: margin;
+  left: 14px;
+  padding: 0 6px;
+}
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dev = [
   "ruff>=0.15,<0.16",
   "typing_extensions>=4.12",
 ]
+desktop = [
+  "PySide6>=6.8,<6.9",
+  "psutil>=7.0,<8",
+]
 image = [
   "Pillow>=10.0",
 ]


### PR DESCRIPTION
## 概要

这个 PR 新增了一个 `desktop client MVP`，用于给 `coding-tools-mcp` 提供一个本地桌面端入口，方便配置 Workspace、公网地址、认证方式，以及启动/停止本地 MCP 运行时。

## 设计边界

- 主要代码都放在 `apps/desktop-client/` 下
- 不修改 `coding_tools_mcp/` 里的核心 runtime/server 主逻辑
- 原有 CLI 和 server 用法保持不变
- `desktop` 依赖是可选依赖，不安装也不影响现有功能
- 桌面端需要显式运行 `python apps/desktop-client/main.py`

## 当前能力

- 多工作区管理
- FRP / Cloudflare 两种公网暴露方式
- OAuth / Bearer / NoAuth 配置
- 启动和停止本地 MCP 运行时
- 日志查看
- 直接复制 ChatGPT 接入需要填写的关键字段

## 额外说明

- 这版更偏 MVP / 实验性能力，后续还可以继续补测试和体验细节
- 真实域名、token、工作区配置只保存在本地，不会写死到仓库代码里
- README 补充了桌面端启动方式

## 验证

- `python -m compileall apps/desktop-client`
- 本地手工 smoke test：
  - 启动/停止桌面客户端
  - Cloudflare quick tunnel 启动与停止
  - 连续启动/停止多轮验证端口释放
