### PR TITLE
Add Beacon Agent Manifest for AI agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coding Tools MCP
 
+[![Beacon Verified](https://registry-ruby.vercel.app/api/v1/agents/xyTom%2Fcoding-tools-mcp/badge.svg)](https://portal-five-phi-54.vercel.app/?q=coding+tools+mcp)
+
 Coding Tools MCP is a model-neutral coding-agent runtime MCP server. It exposes local coding primitives to any MCP client:
 
 ```text

--- a/beacon.json
+++ b/beacon.json
@@ -1,0 +1,12 @@
+{
+  "beacon_manifest": "0.1",
+  "id": "xyTom/coding-tools-mcp",
+  "name": "Coding Tools MCP",
+  "description": "Model-neutral coding-agent runtime MCP — local coding primitives for any MCP client.",
+  "capabilities": ["mcp-server", "coding-agent", "developer-tools", "automation", "cli"],
+  "interfaces": [
+    { "type": "mcp", "endpoint": "https://github.com/xyTom/coding-tools-mcp" }
+  ],
+  "source": "https://github.com/xyTom/coding-tools-mcp",
+  "homepage": "https://github.com/xyTom/coding-tools-mcp"
+}


### PR DESCRIPTION
## Beacon Agent Manifest (optional, ~2 min review)

[Beacon](https://portal-five-phi-54.vercel.app) is an open agent registry (33k+ MCP servers & agents). You are already indexed from GitHub.

This PR adds:
- **`beacon.json`** — [open v0.1 standard](https://github.com/enrichgateagent-png/beacon-agent-manifest) for machine-readable agent discovery (Claude, Cursor MCP, etc.)
- **README badge** — live verification link back to your listing

No API keys, no accounts. Hosting `beacon.json` in your repo is the verification (location = proof).

If merged, Beacon auto-upgrades your listing to **verified manifest** on the next scan.

Spec: https://github.com/enrichgateagent-png/beacon-agent-manifest · [llms.txt](https://registry-ruby.vercel.app/llms.txt)