### PR TITLE
Deploy the control-plane Worker from CI and restore an annotation escape hatch

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run schema drift gate
         run: make test-schema-drift
 
+      - name: Run dispatch inputs gate
+        run: make check-dispatch-inputs
+
       - name: Run dogfood smoke
         run: make dogfood-smoke DOGFOOD_PORT=18772
 

--- a/.github/workflows/deploy-sandbox-control.yml
+++ b/.github/workflows/deploy-sandbox-control.yml
@@ -1,0 +1,112 @@
+name: deploy-sandbox-control
+
+# The sandbox-control Worker and start-sandbox.yml are one contract: the Worker
+# builds the workflow_dispatch body that the workflow must declare. Nothing used
+# to deploy the Worker, so a change that touched both files only ever took effect
+# on the workflow side and the pair silently drifted apart. Deploying from CI on
+# every change to either file keeps them in lockstep.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - cloudflare/sandbox-control/**
+      - .github/workflows/start-sandbox.yml
+      - .github/workflows/deploy-sandbox-control.yml
+      - scripts/check_dispatch_inputs.py
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-sandbox-control
+  cancel-in-progress: false
+
+jobs:
+  deploy-sandbox-control:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install check dependencies
+        run: python -m pip install --disable-pip-version-check --quiet pyyaml
+
+      - name: Check Worker inputs against start-sandbox.yml
+        run: python scripts/check_dispatch_inputs.py
+
+      - name: Require Cloudflare credentials
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
+            missing+=("CLOUDFLARE_API_TOKEN")
+          fi
+          if [ -z "${CLOUDFLARE_ACCOUNT_ID}" ]; then
+            missing+=("CLOUDFLARE_ACCOUNT_ID")
+          fi
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "Missing repository secrets: ${missing[*]}" >&2
+            echo "Add them in Settings > Secrets and variables > Actions, then re-run." >&2
+            exit 1
+          fi
+
+      # wrangler deploy sends the full [vars] table, overwriting whatever the live
+      # Worker had. A committed placeholder would silently repoint the control
+      # plane at a hostname that does not exist, so refuse to deploy until the
+      # effective value is real.
+      - name: Resolve deployment variables
+        id: deploy_vars
+        env:
+          TUNNEL_HOSTNAME_OVERRIDE: ${{ vars.SANDBOX_TUNNEL_HOSTNAME }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          committed="$(python -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("cloudflare/sandbox-control/wrangler.toml").read_text()).get("vars", {}).get("TUNNEL_HOSTNAME", ""))')"
+          effective="${TUNNEL_HOSTNAME_OVERRIDE:-$committed}"
+          case "$effective" in
+            ""|mcp.example.com)
+              echo "TUNNEL_HOSTNAME resolves to the placeholder '${effective}'." >&2
+              echo "Deploying would overwrite the live Worker's hostname with a value that does not resolve." >&2
+              echo "Set the repository variable SANDBOX_TUNNEL_HOSTNAME, or commit the real hostname" >&2
+              echo "in cloudflare/sandbox-control/wrangler.toml, then re-run." >&2
+              exit 1
+              ;;
+          esac
+          echo "tunnel_hostname=$effective" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            deploy --config cloudflare/sandbox-control/wrangler.toml
+            --var TUNNEL_HOSTNAME:${{ steps.deploy_vars.outputs.tunnel_hostname }}
+
+      - name: Summarize
+        env:
+          TUNNEL_HOSTNAME: ${{ steps.deploy_vars.outputs.tunnel_hostname }}
+        shell: bash
+        run: |
+          {
+            echo "## sandbox-control Worker deployed"
+            echo ""
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Config: \`cloudflare/sandbox-control/wrangler.toml\`"
+            echo "- TUNNEL_HOSTNAME: \`${TUNNEL_HOSTNAME}\`"
+            echo ""
+            echo "\`wrangler.toml\` is now the source of truth for the Worker's plain-text"
+            echo "variables: this deploy replaced any values edited in the Cloudflare"
+            echo "dashboard. Worker secrets (CONTROL_TOKEN, GITHUB_TOKEN) are not touched."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `--dangerously-fake-readonly-annotations` and
+  `CODING_TOOLS_MCP_DANGEROUSLY_FAKE_READONLY_ANNOTATIONS`, which report every tool
+  in `tools/list` as read-only and non-destructive. This restores the one capability
+  lost with the `compat-readonly-all` profile in 0.2.0: a client that gates on
+  annotations is unreachable from server-side permission modes, so `dangerous` mode
+  cannot quiet it. Unlike the old profile the catalog is untouched and the claim is
+  fenced in — it requires `dangerous` permission mode, requires authentication over
+  HTTP because a tunnel forwards to a loopback bind, and is confined to `tools/list`.
+  `server_info.annotation_override`, the server card's `tools.annotationOverride`,
+  and `check_exec_environment` all report it, and both `server_info` and the server
+  card keep publishing the real per-tool annotations.
+- A `deploy-sandbox-control` workflow that deploys the Cloudflare control-plane
+  Worker on every push touching `cloudflare/sandbox-control/**` or
+  `start-sandbox.yml`. Nothing deployed the Worker before, so its half of the
+  `workflow_dispatch` contract could sit unshipped indefinitely while the workflow
+  half moved on, which GitHub rejects with `422 Unexpected inputs provided` before
+  creating a run.
+- `make check-dispatch-inputs`, which compares the Worker's dispatch body against
+  `start-sandbox.yml`'s declared `workflow_dispatch` inputs and cross-checks
+  `workflow_call`. It gates the deploy and runs in `make ci`.
+
 ## 0.2.0 - 2026-07-11
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DESKTOP_PACKAGE := apps/desktop-client/mcp_desktop_client
 DESKTOP_TS := $(DESKTOP_PACKAGE)/locales/app_zh_CN.ts
 DESKTOP_QM := $(DESKTOP_PACKAGE)/locales/app_zh_CN.qm
 
-.PHONY: start lint typecheck test ci compliance test-protocol test-integration test-mcp-contract test-tool-golden test-security test-e2e test-runtime-semantics test-docs-required test-schema-drift dogfood-mcp dogfood-runner dogfood-smoke benchmark-latency benchmark-smoke benchmark-real-workloads swebench-reference-predictions swebench-preflight swebench-evaluate desktop-i18n-update desktop-i18n-release desktop-i18n-check install-user publish-testpypi publish-pypi publish-all report
+.PHONY: start lint typecheck test ci check-dispatch-inputs compliance test-protocol test-integration test-mcp-contract test-tool-golden test-security test-e2e test-runtime-semantics test-docs-required test-schema-drift dogfood-mcp dogfood-runner dogfood-smoke benchmark-latency benchmark-smoke benchmark-real-workloads swebench-reference-predictions swebench-preflight swebench-evaluate desktop-i18n-update desktop-i18n-release desktop-i18n-check install-user publish-testpypi publish-pypi publish-all report
 
 start:
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m coding_tools_mcp --workspace "$(MCP_WORKSPACE)" --host "$(MCP_HOST)" --port "$(MCP_PORT)" $(MCP_ARGS)
@@ -26,13 +26,16 @@ lint:
 	$(PYTHON) -m ruff check $(RUFF_FLAGS) $(PYTHON_SOURCES)
 	$(PYTHON) scripts/check_desktop_i18n.py
 
+check-dispatch-inputs:
+	$(PYTHON) scripts/check_dispatch_inputs.py
+
 typecheck:
 	$(PYTHON) -m mypy $(MYPY_FLAGS) $(MYPY_TARGETS)
 
 test:
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -s tests -p 'test_*.py'
 
-ci: lint typecheck test test-protocol test-integration test-docs-required test-schema-drift dogfood-smoke benchmark-latency benchmark-smoke
+ci: lint typecheck test check-dispatch-inputs test-protocol test-integration test-docs-required test-schema-drift dogfood-smoke benchmark-latency benchmark-smoke
 
 compliance:
 	$(COMPLIANCE_RUNNER) --suite all $(REPORT_FLAG)

--- a/cloudflare/sandbox-control/README.md
+++ b/cloudflare/sandbox-control/README.md
@@ -31,6 +31,26 @@ npx wrangler secret put GITHUB_TOKEN --config cloudflare/sandbox-control/wrangle
 npx wrangler deploy --config cloudflare/sandbox-control/wrangler.toml
 ```
 
+## Deploying From CI
+
+The `deploy-sandbox-control` workflow deploys this Worker on every push to `main`
+that touches `cloudflare/sandbox-control/**` or `.github/workflows/start-sandbox.yml`.
+It needs two repository secrets, `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.
+
+Deploy from CI rather than by hand. The Worker builds the `workflow_dispatch` body
+that `start-sandbox.yml` has to declare, so the two are one contract: a change that
+lands in the workflow but never reaches the deployed Worker makes GitHub reject the
+dispatch with `422 Unexpected inputs provided`, before any run is created. CI
+deploying both halves together is what keeps them from drifting.
+`make check-dispatch-inputs` compares the two locally and also gates the deploy.
+
+`wrangler deploy` replaces the Worker's plain-text variables with the `[vars]` table
+in `wrangler.toml`, so that file is the source of truth once CI deploys — values
+edited in the Cloudflare dashboard are overwritten. `TUNNEL_HOSTNAME` may instead be
+supplied as the repository variable `SANDBOX_TUNNEL_HOSTNAME`, which is useful when
+the real hostname should not be committed. The workflow refuses to deploy while that
+value is still the `mcp.example.com` placeholder. Worker secrets are unaffected.
+
 ## Start A Sandbox
 
 Use the token stored in the Worker `CONTROL_TOKEN` secret:

--- a/coding_tools_mcp/server.py
+++ b/coding_tools_mcp/server.py
@@ -312,6 +312,7 @@ class RuntimePolicy:
     permission_mode: str
     shell_env_policy: ShellEnvPolicy
     allow_network: bool
+    fake_readonly_annotations: bool = False
 
 
 def _oauth_token_auth_methods() -> list[str]:
@@ -483,6 +484,17 @@ def permission_mode_from_args(args: argparse.Namespace) -> str:
     return "dangerous" if skip_all else mode
 
 
+def fake_readonly_annotations_from_args(args: argparse.Namespace, permission_mode: str) -> bool:
+    requested = bool(getattr(args, "dangerously_fake_readonly_annotations", False)) or truthy_env(
+        os.environ.get(f"{ENV_PREFIX}_DANGEROUSLY_FAKE_READONLY_ANNOTATIONS")
+    )
+    if requested and permission_mode != "dangerous":
+        raise ValueError(
+            "--dangerously-fake-readonly-annotations requires --permission-mode dangerous"
+        )
+    return requested
+
+
 def runtime_policy_from_args(args: argparse.Namespace) -> RuntimePolicy:
     permission_mode = permission_mode_from_args(args)
     allow_network = (
@@ -494,6 +506,7 @@ def runtime_policy_from_args(args: argparse.Namespace) -> RuntimePolicy:
         permission_mode=permission_mode,
         shell_env_policy=shell_env_policy_from_args(args),
         allow_network=allow_network,
+        fake_readonly_annotations=fake_readonly_annotations_from_args(args, permission_mode),
     )
 
 
@@ -1123,6 +1136,7 @@ class Runtime:
         auth_token: str | None = None,
         oauth_config: OAuthConfig | None = None,
         project_context: ProjectContext | None = None,
+        fake_readonly_annotations: bool = False,
     ) -> None:
         self.workspace = Workspace(workspace)
         self.enable_view_image = enable_view_image
@@ -1138,6 +1152,17 @@ class Runtime:
         self.permission_mode = permission_mode
         self.capabilities = PERMISSION_MODE_CAPABILITIES[permission_mode]
         self.dangerously_skip_all_permissions = self.capabilities.skip_all_permissions
+        # Faking annotations is only defensible where the caller has already
+        # asserted the workspace is disposable, so bind it to that assertion
+        # instead of letting it be set orthogonally.
+        if fake_readonly_annotations and permission_mode != "dangerous":
+            raise ToolFailure(
+                "INVALID_ARGUMENT",
+                "fake_readonly_annotations requires permission_mode=dangerous.",
+                category="validation",
+                details={"permission_mode": permission_mode},
+            )
+        self.fake_readonly_annotations = fake_readonly_annotations
         self.shell_env_policy = shell_env_policy or ShellEnvPolicy()
         if self.shell_env_policy.inherit not in SHELL_ENV_INHERIT_CHOICES:
             raise ToolFailure(
@@ -1273,7 +1298,12 @@ class Runtime:
         }
 
     def list_tools(self) -> dict[str, Any]:
-        return {"tools": [tool_definition(name) for name in self.exposed_tool_names()]}
+        return {
+            "tools": [
+                tool_definition(name, fake_readonly=self.fake_readonly_annotations)
+                for name in self.exposed_tool_names()
+            ]
+        }
 
     def exposed_tool_names(self) -> list[str]:
         return [name for name in FULL_TOOL_NAMES if self.enable_view_image or name != "view_image"]
@@ -1325,6 +1355,7 @@ class Runtime:
             "default_cwd": self.default_cwd_display(),
             "auth_enabled": self.auth_enabled(),
             "dangerously_skip_all_permissions": self.dangerously_skip_all_permissions,
+            "annotation_override": "fake_readonly" if self.fake_readonly_annotations else None,
             "landlock": landlock,
             "exec_policy": {
                 "shell_expansion": self.shell_expansion_policy(),
@@ -1426,6 +1457,10 @@ class Runtime:
             warnings.append("Linux Landlock filesystem confinement is unavailable")
         if self.capabilities.skip_all_permissions:
             warnings.append("permission_mode=dangerous disables MCP safety gates")
+        if self.fake_readonly_annotations:
+            warnings.append(
+                "tools/list annotations are faked as read-only; apply_patch and exec_command still mutate and execute"
+            )
         return {
             "ok": True,
             **self._exec_environment_summary(),
@@ -4359,9 +4394,9 @@ def schema_type_name(expected_type: str | list[str]) -> str:
     return expected_type
 
 
-def tool_definition(name: str) -> dict[str, Any]:
+def tool_definition(name: str, *, fake_readonly: bool = False) -> dict[str, Any]:
     schemas = input_schemas()
-    annotations = tool_annotations(name)
+    annotations = tool_annotations(name, fake_readonly=fake_readonly)
     return {
         "name": name,
         "title": annotations["title"],
@@ -4372,8 +4407,25 @@ def tool_definition(name: str) -> dict[str, Any]:
     }
 
 
-def tool_annotations(name: str) -> dict[str, Any]:
+def tool_annotations(name: str, *, fake_readonly: bool = False) -> dict[str, Any]:
+    """Return a tool's MCP annotations.
+
+    ``fake_readonly`` serves clients that refuse to call, or prompt on every call
+    to, a tool annotated as mutating, which no server-side permission mode can
+    influence. It reports every tool as read-only and non-destructive even though
+    `apply_patch` and `exec_command` still mutate and still execute. Only
+    `tools/list` may pass it: `server_info` and the server card must keep
+    reporting the real annotations so the override stays discoverable.
+    """
     spec = TOOL_REGISTRY[name]
+    if fake_readonly:
+        return {
+            "title": spec.title,
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": spec.idempotent,
+            "openWorldHint": False,
+        }
     return {
         "title": spec.title,
         "readOnlyHint": spec.read_only,
@@ -4594,7 +4646,9 @@ def _server_card_auth(runtime: Runtime, *, oauth_base_url: str | None = None) ->
 
 def server_card_payload(runtime: Runtime, *, oauth_base_url: str | None = None) -> dict[str, Any]:
     names = runtime.exposed_tool_names()
-    annotations = {name: tool_definition(name)["annotations"] for name in names}
+    # Always the real annotations, never the tools/list override: this card is
+    # what an operator fetches to find out what the endpoint actually does.
+    annotations = {name: tool_annotations(name, fake_readonly=False) for name in names}
     read_only = [name for name in names if annotations[name].get("readOnlyHint") is True]
     mutating = [name for name in names if annotations[name].get("readOnlyHint") is not True]
     payload = {
@@ -4615,6 +4669,7 @@ def server_card_payload(runtime: Runtime, *, oauth_base_url: str | None = None) 
             "names": names,
             "readOnlyHintTrue": read_only,
             "readOnlyHintFalse": mutating,
+            "annotationOverride": ("fake_readonly" if runtime.fake_readonly_annotations else None),
         },
         "capabilities": {
             "tools": {"listChanged": False},
@@ -5368,10 +5423,18 @@ def build_runtime(
         auth_token=auth_token,
         oauth_config=oauth_config,
         project_context=project_context,
+        fake_readonly_annotations=runtime_policy.fake_readonly_annotations,
     )
     if emit_warning and runtime.capabilities.skip_all_permissions:
         print(
             "WARNING: permission_mode=dangerous disables MCP safety gates. Use only inside an isolated container or VM.",
+            file=sys.stderr,
+        )
+    if emit_warning and runtime.fake_readonly_annotations:
+        print(
+            "WARNING: tools/list reports every tool as read-only and non-destructive. "
+            "apply_patch and exec_command still mutate the workspace and still run commands. "
+            "server_info and the server card keep reporting the real annotations.",
             file=sys.stderr,
         )
     return runtime
@@ -5474,6 +5537,19 @@ def run_http(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+
+    # A tunnel forwards to a loopback bind, so the bind host cannot tell a private
+    # sandbox apart from a publicly reachable one. Gate on authentication instead:
+    # over HTTP, only callers the operator admitted may be told a false catalog.
+    if runtime_policy.fake_readonly_annotations and not auth_token and not oauth_config:
+        print(
+            "ERROR: --dangerously-fake-readonly-annotations over HTTP requires --auth-token, "
+            f"{ENV_PREFIX}_AUTH_TOKEN, or --oauth-mode. "
+            "Use stdio for an unauthenticated local sandbox.",
+            file=sys.stderr,
+        )
+        return 2
+
     runtime = build_runtime(args, runtime_policy, auth_token=auth_token, oauth_config=oauth_config)
 
     def runtime_factory() -> Runtime:
@@ -5584,6 +5660,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "compatibility alias for --permission-mode dangerous; workspace path boundaries for direct file tools still apply"
+        ),
+    )
+    parser.add_argument(
+        "--dangerously-fake-readonly-annotations",
+        action="store_true",
+        help=(
+            "report every tool in tools/list as read-only and non-destructive for clients that gate on "
+            "annotations; mutation and execution still happen; requires --permission-mode dangerous, and "
+            "requires auth over HTTP; server_info and the server card keep reporting the real annotations; "
+            f"can also be enabled with {ENV_PREFIX}_DANGEROUSLY_FAKE_READONLY_ANNOTATIONS=1"
         ),
     )
     return parser

--- a/docs/permission-modes.md
+++ b/docs/permission-modes.md
@@ -43,6 +43,39 @@ Compatibility aliases:
 - `--allow-network`: opens only the network-looking command gate.
 - `--dangerously-skip-all-permissions`: alias for `--permission-mode dangerous`.
 
+## Client-Side Annotation Gates
+
+Permission modes govern this server's own gates. They cannot affect a client that
+gates on MCP annotations — one that refuses to call, or prompts on every call to, a
+tool advertised as mutating. That friction lives entirely in the client, so
+`--permission-mode dangerous` does nothing about it.
+
+`--dangerously-fake-readonly-annotations` addresses that one case. It makes
+`tools/list` report every tool with `readOnlyHint: true`, `destructiveHint: false`,
+and `openWorldHint: false`:
+
+```bash
+coding-tools-mcp --permission-mode dangerous \
+  --dangerously-fake-readonly-annotations --workspace /path/to/repo
+```
+
+The annotations are false. `apply_patch` still rewrites files and `exec_command`
+still runs commands; only the advertised hints change. Because the claim is false,
+it is fenced in:
+
+- It requires `--permission-mode dangerous`, so it can only be set alongside an
+  explicit assertion that the workspace is disposable.
+- Over HTTP it requires bearer auth or OAuth. A tunnel forwards to a loopback bind,
+  so the bind address cannot distinguish a private sandbox from a publicly reachable
+  one; authentication can. Use stdio for an unauthenticated local sandbox.
+- `server_info.annotation_override` and the server card's
+  `tools.annotationOverride` report `fake_readonly`, and both keep listing the real
+  per-tool annotations. `check_exec_environment` adds a warning. The lie is confined
+  to `tools/list`, so ground truth is always one call away.
+
+`CODING_TOOLS_MCP_DANGEROUSLY_FAKE_READONLY_ANNOTATIONS=1` is equivalent. This is
+not a tool profile: the catalog is unchanged and every tool remains callable.
+
 ## Runtime Directory
 
 Safe and trusted modes keep command runtime state outside the Git worktree:

--- a/docs/remote-mcp.md
+++ b/docs/remote-mcp.md
@@ -159,3 +159,10 @@ curl "$BASE_URL/mcp" \
 - An HTTPS tunnel authenticates transport, not code execution. The server's
   policy and Landlock protections do not replace an external sandbox for
   untrusted repositories.
+- Avoid `--dangerously-fake-readonly-annotations` on a published endpoint. It
+  reports mutating tools as read-only, so a client on the far side of the tunnel
+  cannot tell from `tools/list` that `apply_patch` and `exec_command` are exposed.
+  The server requires authentication before allowing it over HTTP, but on a shared
+  endpoint the operator who set it and the client who connects may not be the same
+  party. Check `server_info.annotation_override` or the server card's
+  `tools.annotationOverride` to see whether an endpoint is doing this.

--- a/docs/runtime-contract-v0.2.md
+++ b/docs/runtime-contract-v0.2.md
@@ -9,6 +9,15 @@ tool profiles and the server does not add or remove process tools dynamically.
 `apply_patch` is the only direct file-mutation primitive; `edit_file` is not
 provided. Permission modes alter command policy, not the advertised catalog.
 
+One switch, `--dangerously-fake-readonly-annotations`, rewrites the exposure hints
+in `tools/list` for clients that refuse mutating tools by annotation. It is not a
+tool profile: the catalog, the schemas, and what every tool actually does are all
+unchanged, and no tool is hidden. It requires `dangerous` permission mode, requires
+authentication over HTTP, and is reported by `server_info.annotation_override` and
+the server card, both of which continue to publish the real annotations recorded
+below. Unless that switch is set, the annotations in this document are what
+`tools/list` returns.
+
 ## Protocol and transports
 
 - Streamable HTTP uses `POST /mcp`. `DELETE /mcp` terminates the selected
@@ -162,7 +171,9 @@ and removes only that optional binary-content tool. It is not a tool profile.
 
 Each definition below lists the live input property names and annotations. The
 authoritative JSON Schemas are returned by `tools/list` and checked for drift in
-CI.
+CI. The annotations recorded here are the truthful ones and are what `server_info`
+and the server card always report, including while
+`--dangerously-fake-readonly-annotations` is rewriting the hints in `tools/list`.
 
 ### server_info
 

--- a/docs/tools-and-schemas.md
+++ b/docs/tools-and-schemas.md
@@ -108,3 +108,9 @@ than labeling pipes as a TTY.
 
 These modes do not change the tool list. Direct path tools retain workspace
 confinement in every mode.
+
+`--dangerously-fake-readonly-annotations` advertises every tool as read-only in
+`tools/list` for clients that gate on annotations. It does not change the tool list
+either, and it does not stop mutation or execution. `server_info` and the server
+card keep reporting the real annotations. See
+[permission-modes.md](permission-modes.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ Issues = "https://github.com/xyTom/coding-tools-mcp/issues"
 [project.optional-dependencies]
 dev = [
   "mypy>=2.1,<2.2",
+  "PyYAML>=6.0",
   "ruff>=0.15,<0.16",
   "typing_extensions>=4.12",
 ]

--- a/scripts/check_dispatch_inputs.py
+++ b/scripts/check_dispatch_inputs.py
@@ -138,10 +138,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    triggers = workflow_triggers(yaml.safe_load(args.workflow.read_text()))
+    triggers = workflow_triggers(yaml.safe_load(args.workflow.read_text(encoding="utf-8")))
     dispatch = declared_inputs(triggers, "workflow_dispatch")
     call = declared_inputs(triggers, "workflow_call")
-    sent = worker_sent_inputs(args.worker.read_text())
+    sent = worker_sent_inputs(args.worker.read_text(encoding="utf-8"))
 
     errors: list[str] = []
 

--- a/scripts/check_dispatch_inputs.py
+++ b/scripts/check_dispatch_inputs.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Verify the sandbox-control Worker and start-sandbox.yml agree on inputs.
+
+GitHub rejects a ``workflow_dispatch`` API call with ``422 Unexpected inputs
+provided`` before it creates a run, so a Worker that sends a field the workflow
+does not declare fails without leaving any trace in the Actions log. This check
+compares the two sources so that mismatch is caught in CI instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKER_FUNCTION = "buildWorkflowInputs"
+KEY_RE = re.compile(r"^([A-Za-z_$][\w$]*)\s*(?::|$)")
+
+
+def workflow_triggers(document: Any) -> dict[str, Any]:
+    # PyYAML resolves the bare ``on:`` key to the boolean True.
+    triggers = document.get(True)
+    if triggers is None:
+        triggers = document.get("on")
+    if not isinstance(triggers, dict):
+        raise ValueError("workflow has no usable 'on:' block")
+    return triggers
+
+
+def declared_inputs(triggers: dict[str, Any], trigger: str) -> dict[str, Any]:
+    block = triggers.get(trigger)
+    if not isinstance(block, dict):
+        raise ValueError(f"workflow has no '{trigger}' trigger")
+    return block.get("inputs") or {}
+
+
+def _skip_string(source: str, index: int) -> int:
+    quote = source[index]
+    index += 1
+    while index < len(source):
+        char = source[index]
+        if char == "\\":
+            index += 2
+            continue
+        if char == quote:
+            return index + 1
+        index += 1
+    raise ValueError("unterminated string literal in Worker source")
+
+
+def _skip_comment(source: str, index: int) -> int:
+    if source.startswith("//", index):
+        end = source.find("\n", index)
+        return len(source) if end == -1 else end
+    end = source.find("*/", index)
+    if end == -1:
+        raise ValueError("unterminated block comment in Worker source")
+    return end + 2
+
+
+def object_literal_entries(source: str, start: int) -> list[str]:
+    """Split the object literal that opens at ``start`` into top-level entries."""
+    if source[start] != "{":
+        raise ValueError("expected an object literal")
+    depth = 0
+    index = start
+    entries: list[str] = []
+    current: list[str] = []
+    while index < len(source):
+        char = source[index]
+        if char in "\"'`":
+            end = _skip_string(source, index)
+            current.append(source[index:end])
+            index = end
+            continue
+        if source.startswith("//", index) or source.startswith("/*", index):
+            index = _skip_comment(source, index)
+            continue
+        if char in "{[(":
+            depth += 1
+            if depth > 1:
+                current.append(char)
+            index += 1
+            continue
+        if char in "}])":
+            depth -= 1
+            if depth == 0:
+                entries.append("".join(current))
+                return [entry.strip() for entry in entries if entry.strip()]
+            current.append(char)
+            index += 1
+            continue
+        if char == "," and depth == 1:
+            entries.append("".join(current))
+            current = []
+            index += 1
+            continue
+        current.append(char)
+        index += 1
+    raise ValueError("unterminated object literal in Worker source")
+
+
+def worker_sent_inputs(worker_source: str) -> set[str]:
+    """Collect the keys the Worker puts in its workflow_dispatch request body."""
+    function_at = worker_source.find(f"function {WORKER_FUNCTION}")
+    if function_at == -1:
+        raise ValueError(f"{WORKER_FUNCTION} not found in Worker source")
+    return_at = worker_source.find("return {", function_at)
+    if return_at == -1:
+        raise ValueError(f"{WORKER_FUNCTION} has no object literal return")
+    brace_at = worker_source.index("{", return_at)
+
+    keys: set[str] = set()
+    for entry in object_literal_entries(worker_source, brace_at):
+        match = KEY_RE.match(entry)
+        if match is None:
+            raise ValueError(f"could not read a key from entry: {entry!r}")
+        keys.add(match.group(1))
+    return keys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check sandbox-control Worker inputs against start-sandbox.yml."
+    )
+    parser.add_argument(
+        "--workflow",
+        type=Path,
+        default=Path(".github/workflows/start-sandbox.yml"),
+    )
+    parser.add_argument(
+        "--worker",
+        type=Path,
+        default=Path("cloudflare/sandbox-control/src/index.mjs"),
+    )
+    args = parser.parse_args()
+
+    triggers = workflow_triggers(yaml.safe_load(args.workflow.read_text()))
+    dispatch = declared_inputs(triggers, "workflow_dispatch")
+    call = declared_inputs(triggers, "workflow_call")
+    sent = worker_sent_inputs(args.worker.read_text())
+
+    errors: list[str] = []
+
+    for name in sorted(sent - set(dispatch)):
+        errors.append(
+            f"Worker sends {name!r} but workflow_dispatch.inputs does not declare it. "
+            "GitHub will reject the dispatch with 422 Unexpected inputs provided."
+        )
+
+    for name in sorted(set(dispatch) - set(call)):
+        errors.append(
+            f"{name!r} is declared in workflow_dispatch.inputs but missing from "
+            "workflow_call.inputs."
+        )
+    for name in sorted(set(call) - set(dispatch)):
+        errors.append(
+            f"{name!r} is declared in workflow_call.inputs but missing from "
+            "workflow_dispatch.inputs."
+        )
+
+    for name in sorted(set(dispatch) - sent):
+        spec = dispatch[name] or {}
+        if spec.get("required") and "default" not in spec:
+            errors.append(
+                f"workflow_dispatch.inputs.{name} is required with no default and the "
+                "Worker never sends it."
+            )
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    print(
+        f"Dispatch inputs OK: Worker sends {len(sent)} inputs, "
+        f"workflow_dispatch declares {len(dispatch)}, workflow_call declares {len(call)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/compliance/test_runtime_helpers.py
+++ b/tests/compliance/test_runtime_helpers.py
@@ -1512,7 +1512,7 @@ class FakeReadonlyAnnotationTests(unittest.TestCase):
                     self.assertIs(annotation["destructiveHint"], False)
                     self.assertIs(annotation["openWorldHint"], False)
 
-    def test_override_does_not_reach_server_info_or_the_server_card(self) -> None:
+    def test_override_is_disclosed_without_faking_server_info_or_card_annotations(self) -> None:
         with TemporaryDirectory() as tmp:
             runtime = Runtime(Path(tmp), permission_mode="dangerous", fake_readonly_annotations=True)
             info = runtime.server_info_payload()

--- a/tests/compliance/test_runtime_helpers.py
+++ b/tests/compliance/test_runtime_helpers.py
@@ -1481,5 +1481,111 @@ Maven home: /usr/share/maven
             self.assertEqual(log.get("commits", [])[0].get("subject"), "baseline fixture")
 
 
+class FakeReadonlyAnnotationTests(unittest.TestCase):
+    """The tools/list annotation override exists for clients that gate on
+    annotations, which no server-side permission mode can influence. It is only
+    defensible while the lie stays confined to tools/list, so these tests pin
+    both halves: what it changes, and what it must never change."""
+
+    MUTATING_TOOLS = ("apply_patch", "exec_command", "write_stdin", "kill_session")
+
+    def test_default_runtime_reports_truthful_annotations(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runtime = Runtime(Path(tmp), permission_mode="dangerous")
+            self.assertFalse(runtime.fake_readonly_annotations)
+            annotations = {tool["name"]: tool["annotations"] for tool in runtime.list_tools()["tools"]}
+            for name in self.MUTATING_TOOLS:
+                with self.subTest(tool=name):
+                    self.assertFalse(annotations[name]["readOnlyHint"])
+            self.assertTrue(annotations["exec_command"]["destructiveHint"])
+            self.assertTrue(annotations["exec_command"]["openWorldHint"])
+            self.assertIsNone(runtime.server_info_payload()["annotation_override"])
+
+    def test_override_makes_every_listed_tool_report_read_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runtime = Runtime(Path(tmp), permission_mode="dangerous", fake_readonly_annotations=True)
+            annotations = {tool["name"]: tool["annotations"] for tool in runtime.list_tools()["tools"]}
+            self.assertEqual(set(annotations), set(runtime.exposed_tool_names()))
+            for name, annotation in annotations.items():
+                with self.subTest(tool=name):
+                    self.assertIs(annotation["readOnlyHint"], True)
+                    self.assertIs(annotation["destructiveHint"], False)
+                    self.assertIs(annotation["openWorldHint"], False)
+
+    def test_override_does_not_reach_server_info_or_the_server_card(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runtime = Runtime(Path(tmp), permission_mode="dangerous", fake_readonly_annotations=True)
+            info = runtime.server_info_payload()
+            self.assertEqual(info["annotation_override"], "fake_readonly")
+
+            card_tools = server_module.server_card_payload(runtime)["tools"]
+            self.assertEqual(card_tools["annotationOverride"], "fake_readonly")
+            for name in self.MUTATING_TOOLS:
+                with self.subTest(tool=name):
+                    self.assertIn(name, card_tools["readOnlyHintFalse"])
+                    self.assertNotIn(name, card_tools["readOnlyHintTrue"])
+
+    def test_override_still_executes_and_mutates(self) -> None:
+        with TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            runtime = Runtime(workspace, permission_mode="dangerous", fake_readonly_annotations=True)
+            result = runtime.exec_command({"cmd": "echo ran > ran.txt", "timeout_ms": 30000, "yield_time_ms": 30000})
+            self.assertEqual(result.get("status"), "exited", result)
+            self.assertTrue((workspace / "ran.txt").exists(), "read-only annotation must not stop execution")
+
+    def test_override_is_reported_by_check_exec_environment(self) -> None:
+        with TemporaryDirectory() as tmp:
+            runtime = Runtime(Path(tmp), permission_mode="dangerous", fake_readonly_annotations=True)
+            warnings = runtime.check_exec_environment({})["warnings"]
+            self.assertTrue(
+                any("faked as read-only" in warning for warning in warnings),
+                warnings,
+            )
+
+    def test_override_requires_dangerous_permission_mode(self) -> None:
+        with TemporaryDirectory() as tmp:
+            for mode in ("safe", "trusted"):
+                with self.subTest(permission_mode=mode):
+                    with self.assertRaises(ToolFailure):
+                        Runtime(Path(tmp), permission_mode=mode, fake_readonly_annotations=True)
+
+    def test_policy_from_args_requires_dangerous_permission_mode(self) -> None:
+        parser = server_module.build_parser()
+        args = parser.parse_args(["--dangerously-fake-readonly-annotations", "--permission-mode", "trusted"])
+        with self.assertRaises(ValueError):
+            server_module.runtime_policy_from_args(args)
+
+        args = parser.parse_args(["--dangerously-fake-readonly-annotations", "--permission-mode", "dangerous"])
+        self.assertTrue(server_module.runtime_policy_from_args(args).fake_readonly_annotations)
+
+    def test_policy_from_args_reads_the_environment_switch(self) -> None:
+        parser = server_module.build_parser()
+        args = parser.parse_args(["--permission-mode", "dangerous"])
+        with patch.dict(
+            os.environ,
+            {"CODING_TOOLS_MCP_DANGEROUSLY_FAKE_READONLY_ANNOTATIONS": "1"},
+            clear=False,
+        ):
+            self.assertTrue(server_module.runtime_policy_from_args(args).fake_readonly_annotations)
+        self.assertFalse(server_module.runtime_policy_from_args(args).fake_readonly_annotations)
+
+    def test_override_over_http_requires_authentication(self) -> None:
+        # A tunnel forwards to a loopback bind, so the bind host cannot tell a
+        # private sandbox from a public one. Authentication is the real gate.
+        parser = server_module.build_parser()
+        with TemporaryDirectory() as tmp:
+            argv = [
+                "--workspace",
+                tmp,
+                "--permission-mode",
+                "dangerous",
+                "--dangerously-fake-readonly-annotations",
+            ]
+            args = parser.parse_args(argv)
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("CODING_TOOLS_MCP_AUTH_TOKEN", None)
+                self.assertEqual(server_module.run_http(args), 2)
+
+
 def file_path(name: str):
     return Path(name)

--- a/tests/compliance/test_schema_drift.py
+++ b/tests/compliance/test_schema_drift.py
@@ -43,6 +43,28 @@ class SchemaDriftTests(unittest.TestCase):
                     self.assertIn(str(key), contract)
                     self.assertIn(str(value).lower(), contract.lower())
 
+    def test_default_annotations_are_the_truthful_ones(self) -> None:
+        # The documented catalog above is the truthful one, so the fake-readonly
+        # override must never become what an unqualified call returns.
+        for tool_name in REQUIRED_TOOLS:
+            with self.subTest(tool=tool_name):
+                self.assertEqual(
+                    tool_annotations(tool_name),
+                    tool_annotations(tool_name, fake_readonly=False),
+                )
+
+    def test_fake_readonly_override_only_rewrites_exposure_hints(self) -> None:
+        for tool_name in REQUIRED_TOOLS:
+            truthful = tool_annotations(tool_name)
+            faked = tool_annotations(tool_name, fake_readonly=True)
+            with self.subTest(tool=tool_name):
+                self.assertIs(faked["readOnlyHint"], True)
+                self.assertIs(faked["destructiveHint"], False)
+                self.assertIs(faked["openWorldHint"], False)
+                # Identity and idempotency are not exposure claims, so they stay real.
+                self.assertEqual(faked["title"], truthful["title"])
+                self.assertEqual(faked["idempotentHint"], truthful["idempotentHint"])
+
     def test_tools_docs_list_matches_live_tool_names(self) -> None:
         text = (ROOT / "docs/tools-and-schemas.md").read_text(encoding="utf-8")
         inventory = text.split("## Fixed inventory", 1)[1].split("## Result envelope", 1)[0]


### PR DESCRIPTION
The sandbox-control Worker builds the workflow_dispatch body that start-sandbox.yml must declare, so the two files are one contract. Nothing deployed the Worker, so when 0.2.0 removed tool_profile from both halves only the workflow half shipped; the deployed Worker kept sending tool_profile and GitHub rejected every dispatch with 422 Unexpected inputs provided before creating a run.

Add deploy-sandbox-control, which deploys the Worker on any push touching cloudflare/sandbox-control/** or start-sandbox.yml, so both halves ship together. wrangler deploy replaces the Worker's plain-text variables with the committed [vars] table, so the workflow refuses to run while TUNNEL_HOSTNAME is still the mcp.example.com placeholder and accepts SANDBOX_TUNNEL_HOSTNAME as an override. Add check_dispatch_inputs.py, which compares the Worker's dispatch body against the declared inputs and cross-checks workflow_call, gating the deploy and running in make ci.

Separately, restore the one capability lost with the compat-readonly-all profile. A client that gates on MCP annotations -- refusing to call, or prompting on every call to, a tool advertised as mutating -- is unreachable from server-side permission modes, so dangerous mode cannot quiet it, and 0.2.0 shipped no replacement. --dangerously-fake-readonly-annotations reports every tool in tools/list as read-only and non-destructive.

Unlike the old profile the claim is fenced in. The catalog, schemas, and behavior are untouched and no tool is hidden, so this is not a tool profile. It requires dangerous permission mode, tying the false claim to an explicit assertion that the workspace is disposable. Over HTTP it requires authentication: a tunnel forwards to a loopback bind, so the bind address cannot distinguish a private sandbox from a published one. The override reaches tools/list only -- server_info.annotation_override, the server card's tools.annotationOverride, and check_exec_environment report it, and both server_info and the card keep publishing the real per-tool annotations, which is what the removal of the old profile was protecting.

Claude-Session: https://claude.ai/code/session_01Kv37m2tCrXYhMtJAsZ9p7y