### PR TITLE
release: harden 0.2.0 publishing (audited, provenance-bound)

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Install runtime and CI tools
         run: |
           python -m pip install --upgrade pip
@@ -48,6 +53,9 @@ jobs:
 
       - name: Run dispatch inputs gate
         run: make check-dispatch-inputs
+
+      - name: Run npm launcher gate
+        run: make check-npm-launcher
 
       - name: Run dogfood smoke
         run: make dogfood-smoke DOGFOOD_PORT=18772

--- a/.github/workflows/final-audit.yml
+++ b/.github/workflows/final-audit.yml
@@ -15,7 +15,7 @@ on:
       release_tag:
         description: "Release tag that points at this commit"
         required: true
-        default: "v0.1.3-recovered-final"
+        default: "v0.2.0"
 
 jobs:
   final-audit:
@@ -27,6 +27,20 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag and metadata
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+          if [ "$tag_sha" != "$EXPECTED_SHA" ]; then
+            echo "release tag $RELEASE_TAG points to $tag_sha, expected $EXPECTED_SHA" >&2
+            exit 1
+          fi
+          python scripts/check_release_versions.py --tag "$RELEASE_TAG"
 
       - name: Validate referenced runs
         env:

--- a/.github/workflows/final-audit.yml
+++ b/.github/workflows/final-audit.yml
@@ -15,7 +15,6 @@ on:
       release_tag:
         description: "Release tag that points at this commit"
         required: true
-        default: "v0.2.0"
 
 jobs:
   final-audit:
@@ -30,12 +29,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
       - name: Validate release tag and metadata
         env:
           EXPECTED_SHA: ${{ github.sha }}
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+          expected_ref="refs/tags/$RELEASE_TAG"
+          if [ "$GITHUB_REF" != "$expected_ref" ]; then
+            echo "workflow ref $GITHUB_REF does not match release ref $expected_ref" >&2
+            exit 1
+          fi
           if [ "$tag_sha" != "$EXPECTED_SHA" ]; then
             echo "release tag $RELEASE_TAG points to $tag_sha, expected $EXPECTED_SHA" >&2
             exit 1

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,8 +1,6 @@
 name: publish-npm
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -11,6 +9,7 @@ on:
         default: "v0.2.0"
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -18,7 +17,7 @@ jobs:
     name: Test and pack npm launcher
     runs-on: ubuntu-latest
     env:
-      RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -31,13 +30,22 @@ jobs:
           python-version: "3.11"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Validate release metadata
         run: python scripts/check_release_versions.py --tag "$RELEASE_TAG"
+
+      - name: Require final audit for release commit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_final_audit.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --sha "$(git rev-parse HEAD)"
 
       - name: Test launcher
         run: make check-npm-launcher
@@ -72,13 +80,14 @@ jobs:
           path: dist
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
-      - name: Install current npm CLI
-        run: npm install --global npm@latest
+      - name: Install OIDC-capable npm CLI
+        run: npm install --global npm@11.18.0
 
       - name: Publish launcher with provenance
         run: npm publish dist/*.tgz --access public --provenance

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,7 +6,6 @@ on:
       release_tag:
         description: "Existing Python release tag that includes the launcher"
         required: true
-        default: "v0.2.0"
 
 permissions:
   actions: read
@@ -23,6 +22,7 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
@@ -38,6 +38,20 @@ jobs:
 
       - name: Validate release metadata
         run: python scripts/check_release_versions.py --tag "$RELEASE_TAG"
+
+      - name: Validate release ref and provenance commit
+        run: |
+          tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+          expected_ref="refs/tags/$RELEASE_TAG"
+          checkout_sha="$(git rev-parse HEAD)"
+          if [ "$GITHUB_REF" != "$expected_ref" ]; then
+            echo "workflow ref $GITHUB_REF does not match release ref $expected_ref" >&2
+            exit 1
+          fi
+          if [ "$GITHUB_SHA" != "$tag_sha" ] || [ "$checkout_sha" != "$tag_sha" ]; then
+            echo "release commit mismatch: event=$GITHUB_SHA checkout=$checkout_sha tag=$tag_sha" >&2
+            exit 1
+          fi
 
       - name: Require final audit for release commit
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,84 @@
+name: publish-npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing Python release tag that includes the launcher"
+        required: true
+        default: "v0.2.0"
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-pack:
+    name: Test and pack npm launcher
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Validate release metadata
+        run: python scripts/check_release_versions.py --tag "$RELEASE_TAG"
+
+      - name: Test launcher
+        run: make check-npm-launcher
+
+      - name: Pack launcher
+        working-directory: npm/coding-tools-mcp
+        run: npm pack
+
+      - name: Upload npm package artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: npm-package-distribution
+          path: npm/coding-tools-mcp/*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-to-npm:
+    name: Publish npm launcher
+    needs: test-and-pack
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/coding-tools-mcp
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download npm package artifact
+        uses: actions/download-artifact@v7.0.0
+        with:
+          name: npm-package-distribution
+          path: dist
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install current npm CLI
+        run: npm install --global npm@latest
+
+      - name: Publish launcher with provenance
+        run: npm publish dist/*.tgz --access public --provenance

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,6 +11,7 @@ on:
         default: "v0.2.0"
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -37,6 +38,14 @@ jobs:
 
       - name: Validate release metadata
         run: python scripts/check_release_versions.py --tag "$RELEASE_TAG"
+
+      - name: Require final audit for release commit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_final_audit.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --sha "$(git rev-parse HEAD)"
 
       - name: Build source and wheel distributions
         run: python -m build

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to publish"
+        required: true
+        default: "v0.2.0"
 
 permissions:
   contents: read
@@ -12,9 +17,13 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
@@ -26,11 +35,53 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install build twine
 
+      - name: Validate release metadata
+        run: python scripts/check_release_versions.py --tag "$RELEASE_TAG"
+
       - name: Build source and wheel distributions
         run: python -m build
 
       - name: Check distribution metadata
         run: python -m twine check dist/*
+
+      - name: Verify wheel contents and installation
+        run: |
+          python - <<'PY'
+          import glob
+          import zipfile
+
+          wheel = glob.glob("dist/*.whl")
+          if len(wheel) != 1:
+              raise SystemExit(f"expected one wheel, found {wheel}")
+          required = {
+              "coding_tools_mcp/__init__.py",
+              "mcp_desktop_client/app.py",
+              "mcp_desktop_client/locales/app_zh_CN.qm",
+              "mcp_desktop_client/locales/app_zh_CN.ts",
+          }
+          with zipfile.ZipFile(wheel[0]) as archive:
+              names = set(archive.namelist())
+              missing = sorted(required - names)
+              if missing:
+                  raise SystemExit(f"wheel is missing: {missing}")
+              entry_points = archive.read(
+                  next(name for name in names if name.endswith("entry_points.txt"))
+              ).decode()
+              for command in ("coding-tools-mcp", "coding-tools-mcp-desktop"):
+                  if command not in entry_points:
+                      raise SystemExit(f"wheel entry point is missing: {command}")
+          PY
+          python -m venv .package-verify
+          .package-verify/bin/python -m pip install dist/*.whl
+          .package-verify/bin/coding-tools-mcp --help >/dev/null
+          .package-verify/bin/python - <<'PY'
+          import coding_tools_mcp
+          import tomllib
+
+          with open("pyproject.toml", "rb") as handle:
+              expected = tomllib.load(handle)["project"]["version"]
+          assert coding_tools_mcp.__version__ == expected
+          PY
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -8,7 +8,6 @@ on:
       release_tag:
         description: "Existing release tag to publish"
         required: true
-        default: "v0.2.0"
 
 permissions:
   actions: read
@@ -25,6 +24,7 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
@@ -38,6 +38,20 @@ jobs:
 
       - name: Validate release metadata
         run: python scripts/check_release_versions.py --tag "$RELEASE_TAG"
+
+      - name: Validate release ref and provenance commit
+        run: |
+          tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+          expected_ref="refs/tags/$RELEASE_TAG"
+          checkout_sha="$(git rev-parse HEAD)"
+          if [ "$GITHUB_REF" != "$expected_ref" ]; then
+            echo "workflow ref $GITHUB_REF does not match release ref $expected_ref" >&2
+            exit 1
+          fi
+          if [ "$GITHUB_SHA" != "$tag_sha" ] || [ "$checkout_sha" != "$tag_sha" ]; then
+            echo "release commit mismatch: event=$GITHUB_SHA checkout=$checkout_sha tag=$tag_sha" >&2
+            exit 1
+          fi
 
       - name: Require final audit for release commit
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Added
-
-- `--dangerously-fake-readonly-annotations` and
-  `CODING_TOOLS_MCP_DANGEROUSLY_FAKE_READONLY_ANNOTATIONS`, which report every tool
-  in `tools/list` as read-only and non-destructive. This restores the one capability
-  lost with the `compat-readonly-all` profile in 0.2.0: a client that gates on
-  annotations is unreachable from server-side permission modes, so `dangerous` mode
-  cannot quiet it. Unlike the old profile the catalog is untouched and the claim is
-  fenced in — it requires `dangerous` permission mode, requires authentication over
-  HTTP because a tunnel forwards to a loopback bind, and is confined to `tools/list`.
-  `server_info.annotation_override`, the server card's `tools.annotationOverride`,
-  and `check_exec_environment` all report it, and both `server_info` and the server
-  card keep publishing the real per-tool annotations.
-- A `deploy-sandbox-control` workflow that deploys the Cloudflare control-plane
-  Worker on every push touching `cloudflare/sandbox-control/**` or
-  `start-sandbox.yml`. Nothing deployed the Worker before, so its half of the
-  `workflow_dispatch` contract could sit unshipped indefinitely while the workflow
-  half moved on, which GitHub rejects with `422 Unexpected inputs provided` before
-  creating a run.
-- `make check-dispatch-inputs`, which compares the Worker's dispatch body against
-  `start-sandbox.yml`'s declared `workflow_dispatch` inputs and cross-checks
-  `workflow_call`. It gates the deploy and runs in `make ci`.
-
 ## 0.2.0 - 2026-07-24
 
 ### Changed
@@ -99,6 +74,26 @@
   `auth_token`, and `hide_auth_token`, so a sandbox can publish one reusable
   Cloudflare named hostname with a secret-managed bearer token kept out of
   workflow logs and run summaries.
+- `--dangerously-fake-readonly-annotations` and
+  `CODING_TOOLS_MCP_DANGEROUSLY_FAKE_READONLY_ANNOTATIONS`, which report every tool
+  in `tools/list` as read-only and non-destructive. This restores the one capability
+  lost when the `compat-readonly-all` profile was removed: a client that gates on
+  annotations is unreachable from server-side permission modes, so `dangerous` mode
+  cannot quiet it. Unlike the old profile the catalog is untouched and the claim is
+  fenced in — it requires `dangerous` permission mode, requires authentication over
+  HTTP because a tunnel forwards to a loopback bind, and is confined to `tools/list`.
+  `server_info.annotation_override`, the server card's `tools.annotationOverride`,
+  and `check_exec_environment` all report it, and both `server_info` and the server
+  card keep publishing the real per-tool annotations.
+- A `deploy-sandbox-control` workflow that deploys the Cloudflare control-plane
+  Worker on every push touching `cloudflare/sandbox-control/**` or
+  `start-sandbox.yml`. Nothing deployed the Worker before, so its half of the
+  `workflow_dispatch` contract could sit unshipped indefinitely while the workflow
+  half moved on, which GitHub rejects with `422 Unexpected inputs provided` before
+  creating a run.
+- `make check-dispatch-inputs`, which compares the Worker's dispatch body against
+  `start-sandbox.yml`'s declared `workflow_dispatch` inputs and cross-checks
+  `workflow_call`. It gates the deploy and runs in `make ci`.
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 PYTHON ?= python3
+PROJECT_VERSION := $(shell $(PYTHON) -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+RELEASE_TAG ?= v$(PROJECT_VERSION)
 COMPLIANCE_RUNNER := PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m tests.compliance.runner
 PYTHON_SOURCES := coding_tools_mcp apps/desktop-client/mcp_desktop_client tests benchmarks
 MYPY_TARGETS := coding_tools_mcp benchmarks/mcp_http.py benchmarks/runtime_latency.py benchmarks/swebench/run_smoke.py benchmarks/swebench/generate_reference_predictions.py benchmarks/real_workloads.py
@@ -34,7 +36,7 @@ check-npm-launcher:
 	cd npm/coding-tools-mcp && npm pack --dry-run --json >/dev/null
 
 check-release:
-	$(PYTHON) scripts/check_release_versions.py --tag v0.2.0
+	$(PYTHON) scripts/check_release_versions.py --tag "$(RELEASE_TAG)"
 
 typecheck:
 	$(PYTHON) -m mypy $(MYPY_FLAGS) $(MYPY_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DESKTOP_PACKAGE := apps/desktop-client/mcp_desktop_client
 DESKTOP_TS := $(DESKTOP_PACKAGE)/locales/app_zh_CN.ts
 DESKTOP_QM := $(DESKTOP_PACKAGE)/locales/app_zh_CN.qm
 
-.PHONY: start lint typecheck test ci check-dispatch-inputs compliance test-protocol test-integration test-mcp-contract test-tool-golden test-security test-e2e test-runtime-semantics test-docs-required test-schema-drift dogfood-mcp dogfood-runner dogfood-smoke benchmark-latency benchmark-smoke benchmark-real-workloads swebench-reference-predictions swebench-preflight swebench-evaluate desktop-i18n-update desktop-i18n-release desktop-i18n-check install-user publish-testpypi publish-pypi publish-all report
+.PHONY: start lint typecheck test ci check-dispatch-inputs check-npm-launcher check-release compliance test-protocol test-integration test-mcp-contract test-tool-golden test-security test-e2e test-runtime-semantics test-docs-required test-schema-drift dogfood-mcp dogfood-runner dogfood-smoke benchmark-latency benchmark-smoke benchmark-real-workloads swebench-reference-predictions swebench-preflight swebench-evaluate desktop-i18n-update desktop-i18n-release desktop-i18n-check install-user publish-testpypi publish-pypi publish-all report
 
 start:
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m coding_tools_mcp --workspace "$(MCP_WORKSPACE)" --host "$(MCP_HOST)" --port "$(MCP_PORT)" $(MCP_ARGS)
@@ -29,13 +29,20 @@ lint:
 check-dispatch-inputs:
 	$(PYTHON) scripts/check_dispatch_inputs.py
 
+check-npm-launcher:
+	cd npm/coding-tools-mcp && npm test
+	cd npm/coding-tools-mcp && npm pack --dry-run --json >/dev/null
+
+check-release:
+	$(PYTHON) scripts/check_release_versions.py --tag v0.2.0
+
 typecheck:
 	$(PYTHON) -m mypy $(MYPY_FLAGS) $(MYPY_TARGETS)
 
 test:
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -s tests -p 'test_*.py'
 
-ci: lint typecheck test check-dispatch-inputs test-protocol test-integration test-docs-required test-schema-drift dogfood-smoke benchmark-latency benchmark-smoke
+ci: lint typecheck test check-dispatch-inputs check-npm-launcher test-protocol test-integration test-docs-required test-schema-drift dogfood-smoke benchmark-latency benchmark-smoke
 
 compliance:
 	$(COMPLIANCE_RUNNER) --suite all $(REPORT_FLAG)

--- a/docs/ci-and-tests.md
+++ b/docs/ci-and-tests.md
@@ -11,16 +11,33 @@ make ci
 
 `make compliance` runs the full compliance suite and writes `reports/compliance/latest.json` and `reports/compliance/latest.md`.
 
-`make ci` mirrors the main CI workflow: lint, typecheck, unittest discovery, protocol tests, integration/security tests, required docs checks, schema drift checks, dogfood smoke, and SWE-bench smoke preflight.
+`make ci` mirrors the main CI workflow: lint, typecheck, unittest discovery, npm launcher checks, protocol tests, integration/security tests, required docs checks, schema drift checks, dogfood smoke, and SWE-bench smoke preflight. It requires Python 3.11 or newer plus Node.js 18 or newer and npm; GitHub Actions uses Node.js 22.
 
 Report files are overwritten by whichever suite or benchmark was run most recently. Check `suite` in compliance reports and `conclusion` in benchmark reports before citing them.
 
 ## PyPI Release
 
-The release commit must have successful `compliance`, `real-workloads`,
-`swebench-lite`, and `final-audit` workflow runs before either registry publish
-workflow will proceed. Create `v<project-version>` at that exact commit, run the
-three evidence workflows, then run `final-audit` with their run IDs.
+The `final-audit` workflow is a release-only gate. The release commit must have
+successful `compliance`, `real-workloads`, `swebench-lite`, and `final-audit`
+workflow runs before either registry publish workflow will proceed.
+
+Use this order so a GitHub Release never starts publishing before its evidence
+exists:
+
+1. Merge the final release commit.
+2. Create and push `v<project-version>` at that exact commit, but do not publish
+   the GitHub Release yet.
+3. Dispatch `compliance`, `real-workloads`, and `swebench-lite` from that tag.
+4. Dispatch `final-audit` from the same tag with those three run IDs and the tag.
+5. After `final-audit` succeeds, publish the GitHub Release to trigger PyPI.
+6. Dispatch `publish-npm` from the same tag and pass that tag as `release_tag`.
+
+Dispatch release workflows with the tag as the workflow ref, for example
+`gh workflow run <workflow>.yml --ref v0.2.0`. Pass `release_tag=v0.2.0` to
+workflows that declare that input. The publish workflows reject a branch
+dispatch even when its `release_tag` input names a valid tag, because the
+workflow ref, event SHA, checked-out commit, audit evidence, and registry
+provenance must all identify the same release commit.
 
 Publishing a GitHub Release triggers `.github/workflows/publish-pypi.yml`. The
 workflow checks out the release tag, validates package and changelog versions,
@@ -54,6 +71,9 @@ The helper expects `TWINE_USERNAME`/`TWINE_PASSWORD` or `~/.pypirc` credentials.
 ## Individual Gates
 
 ```bash
+make check-dispatch-inputs
+make check-npm-launcher
+make check-release
 make test-mcp-contract
 make test-tool-golden
 make test-security
@@ -70,6 +90,9 @@ make benchmark-real-workloads
 
 | Command | Coverage |
 | --- | --- |
+| `make check-dispatch-inputs` | Cloudflare Worker dispatch body compared with the sandbox workflow inputs |
+| `make check-npm-launcher` | npm launcher argument forwarding, runner fallback, exit behavior, and package contents |
+| `make check-release` | Python/module/npm versions and release changelog checked against `RELEASE_TAG`, which defaults from `pyproject.toml` |
 | `make test-mcp-contract` | MCP initialize, `tools/list`, schemas, annotations, structured success/error envelopes, protocol errors |
 | `make test-tool-golden` | Golden behavior for read/list/search/patch/exec/stdin/kill/git/image paths |
 | `make test-security` | Traversal, symlink escape, command workdir escape, risky env, shell-expansion gating, Linux Landlock fallback behavior, direct syscall denial where Landlock is available, timeout/watchdog, buffer caps |

--- a/docs/ci-and-tests.md
+++ b/docs/ci-and-tests.md
@@ -17,7 +17,26 @@ Report files are overwritten by whichever suite or benchmark was run most recent
 
 ## PyPI Release
 
-Publish through the release helper so the same build, check, upload, and install-verification flow is used every time:
+The release commit must have successful `compliance`, `real-workloads`,
+`swebench-lite`, and `final-audit` workflow runs before either registry publish
+workflow will proceed. Create `v<project-version>` at that exact commit, run the
+three evidence workflows, then run `final-audit` with their run IDs.
+
+Publishing a GitHub Release triggers `.github/workflows/publish-pypi.yml`. The
+workflow checks out the release tag, validates package and changelog versions,
+requires a successful `final-audit` for the same commit, builds the wheel and
+sdist, inspects desktop resources and entry points, installs the wheel in a
+clean environment, and only then publishes through PyPI trusted publishing.
+
+The npm launcher has its own version and is published independently. Run the
+manual `.github/workflows/publish-npm.yml` workflow with the Python release tag
+that contains the launcher source. It runs the launcher tests, packs npm
+`coding-tools-mcp`, requires the same final audit, and publishes through npm
+trusted publishing. Bump `npm/coding-tools-mcp/package.json` before every npm
+release; npm package versions cannot be overwritten.
+
+For local or recovery publishing, use the release helper so the same build,
+check, upload, and install-verification flow is used every time:
 
 ```bash
 make publish-testpypi

--- a/npm/coding-tools-mcp/package.json
+++ b/npm/coding-tools-mcp/package.json
@@ -4,6 +4,9 @@
   "description": "npm launcher for the coding-tools-mcp Python MCP server (PyPI). Starts the server via uvx or pipx.",
   "type": "module",
   "license": "Apache-2.0",
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/npm/coding-tools-mcp/test/launcher.test.js
+++ b/npm/coding-tools-mcp/test/launcher.test.js
@@ -16,11 +16,13 @@ async function writeExecutable(directory, name, body) {
   return target;
 }
 
-function runLauncher(binDirectory, args = [], extraEnv = {}) {
+function runLauncher(binDirectory, args = [], extraEnv = {}, ambientEnv = process.env) {
+  const env = { ...ambientEnv };
+  delete env.CODING_TOOLS_MCP_VERSION;
   return spawnSync(process.execPath, [launcher, ...args], {
     encoding: "utf8",
     env: {
-      ...process.env,
+      ...env,
       ...extraEnv,
       PATH: binDirectory,
     },
@@ -51,7 +53,12 @@ test("pipx is used when uvx is unavailable", async () => {
   const output = path.join(directory, "args.txt");
   await writeExecutable(directory, "pipx", 'printf "%s\\n" "$@" > "$RESULT_FILE"');
 
-  const result = runLauncher(directory, ["--help"], { RESULT_FILE: output });
+  const result = runLauncher(
+    directory,
+    ["--help"],
+    { RESULT_FILE: output },
+    { ...process.env, CODING_TOOLS_MCP_VERSION: "9.9.9" },
+  );
 
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual((await readFile(output, "utf8")).trim().split("\n"), [

--- a/npm/coding-tools-mcp/test/launcher.test.js
+++ b/npm/coding-tools-mcp/test/launcher.test.js
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const launcher = path.join(packageRoot, "bin", "coding-tools-mcp.js");
+
+async function writeExecutable(directory, name, body) {
+  const target = path.join(directory, name);
+  await writeFile(target, `#!/bin/sh\n${body}\n`, "utf8");
+  await chmod(target, 0o755);
+  return target;
+}
+
+function runLauncher(binDirectory, args = [], extraEnv = {}) {
+  return spawnSync(process.execPath, [launcher, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...extraEnv,
+      PATH: binDirectory,
+    },
+  });
+}
+
+test("uvx receives the pinned Python package and forwarded arguments", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "coding-tools-mcp-uvx-"));
+  const output = path.join(directory, "args.txt");
+  await writeExecutable(directory, "uvx", 'printf "%s\\n" "$@" > "$RESULT_FILE"');
+
+  const result = runLauncher(directory, ["--stdio", "--workspace", "/repo"], {
+    CODING_TOOLS_MCP_VERSION: "0.2.0",
+    RESULT_FILE: output,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual((await readFile(output, "utf8")).trim().split("\n"), [
+    "coding-tools-mcp==0.2.0",
+    "--stdio",
+    "--workspace",
+    "/repo",
+  ]);
+});
+
+test("pipx is used when uvx is unavailable", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "coding-tools-mcp-pipx-"));
+  const output = path.join(directory, "args.txt");
+  await writeExecutable(directory, "pipx", 'printf "%s\\n" "$@" > "$RESULT_FILE"');
+
+  const result = runLauncher(directory, ["--help"], { RESULT_FILE: output });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual((await readFile(output, "utf8")).trim().split("\n"), [
+    "run",
+    "coding-tools-mcp",
+    "--help",
+  ]);
+});
+
+test("the launcher explains how to install a supported runner", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "coding-tools-mcp-empty-"));
+  const result = runLauncher(directory);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /neither uvx nor pipx was found/);
+  assert.match(result.stderr, /pip install coding-tools-mcp/);
+});
+
+test("the child exit code is preserved", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "coding-tools-mcp-exit-"));
+  await writeExecutable(directory, "uvx", "exit 7");
+
+  const result = runLauncher(directory);
+
+  assert.equal(result.status, 7);
+});

--- a/scripts/check_final_audit.py
+++ b/scripts/check_final_audit.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import os
 from urllib.error import HTTPError
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
 
@@ -24,35 +24,35 @@ def select_successful_run(workflow_runs: list[dict[str, object]], sha: str) -> d
     return max(matches, key=lambda run: int(run.get("id", 0)))
 
 
-def fetch_runs(api_url: str, repo: str, workflow: str, token: str) -> list[dict[str, object]]:
+def workflow_runs_url(api_url: str, repo: str, workflow: str, sha: str) -> str:
     owner, name = repo.split("/", 1)
     base = (
         f"{api_url.rstrip('/')}/repos/{quote(owner, safe='')}/{quote(name, safe='')}"
         f"/actions/workflows/{quote(workflow, safe='')}/runs"
     )
-    runs: list[dict[str, object]] = []
-    for page in range(1, 11):
-        request = Request(
-            f"{base}?status=success&per_page=100&page={page}",
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {token}",
-                "X-GitHub-Api-Version": "2022-11-28",
-                "User-Agent": "coding-tools-mcp-release-audit",
-            },
-        )
-        try:
-            with urlopen(request, timeout=30) as response:
-                payload = json.load(response)
-        except HTTPError as error:
-            detail = error.read().decode("utf-8", errors="replace")
-            raise SystemExit(f"GitHub Actions API failed with {error.code}: {detail}") from error
-        page_runs = payload.get("workflow_runs", [])
-        if not isinstance(page_runs, list):
-            raise SystemExit("GitHub Actions API returned an invalid workflow_runs payload")
-        runs.extend(page_runs)
-        if len(page_runs) < 100:
-            break
+    query = urlencode({"status": "success", "head_sha": sha, "per_page": 100})
+    return f"{base}?{query}"
+
+
+def fetch_runs(api_url: str, repo: str, workflow: str, sha: str, token: str) -> list[dict[str, object]]:
+    request = Request(
+        workflow_runs_url(api_url, repo, workflow, sha),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "coding-tools-mcp-release-audit",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"GitHub Actions API failed with {error.code}: {detail}") from error
+    runs = payload.get("workflow_runs", [])
+    if not isinstance(runs, list):
+        raise SystemExit("GitHub Actions API returned an invalid workflow_runs payload")
     return runs
 
 
@@ -67,7 +67,9 @@ def main() -> int:
     if not token:
         raise SystemExit("GITHUB_TOKEN is required to verify final-audit evidence")
     api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
-    run = select_successful_run(fetch_runs(api_url, args.repo, args.workflow, token), args.sha)
+    run = select_successful_run(
+        fetch_runs(api_url, args.repo, args.workflow, args.sha, token), args.sha
+    )
     if run is None:
         raise SystemExit(
             f"no successful {args.workflow} run was found for release commit {args.sha}"

--- a/scripts/check_final_audit.py
+++ b/scripts/check_final_audit.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Require a successful final-audit workflow run for a release commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+def select_successful_run(workflow_runs: list[dict[str, object]], sha: str) -> dict[str, object] | None:
+    matches = [
+        run
+        for run in workflow_runs
+        if run.get("head_sha") == sha
+        and run.get("status") == "completed"
+        and run.get("conclusion") == "success"
+    ]
+    if not matches:
+        return None
+    return max(matches, key=lambda run: int(run.get("id", 0)))
+
+
+def fetch_runs(api_url: str, repo: str, workflow: str, token: str) -> list[dict[str, object]]:
+    owner, name = repo.split("/", 1)
+    base = (
+        f"{api_url.rstrip('/')}/repos/{quote(owner, safe='')}/{quote(name, safe='')}"
+        f"/actions/workflows/{quote(workflow, safe='')}/runs"
+    )
+    runs: list[dict[str, object]] = []
+    for page in range(1, 11):
+        request = Request(
+            f"{base}?status=success&per_page=100&page={page}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "coding-tools-mcp-release-audit",
+            },
+        )
+        try:
+            with urlopen(request, timeout=30) as response:
+                payload = json.load(response)
+        except HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise SystemExit(f"GitHub Actions API failed with {error.code}: {detail}") from error
+        page_runs = payload.get("workflow_runs", [])
+        if not isinstance(page_runs, list):
+            raise SystemExit("GitHub Actions API returned an invalid workflow_runs payload")
+        runs.extend(page_runs)
+        if len(page_runs) < 100:
+            break
+    return runs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True, help="GitHub repository as owner/name")
+    parser.add_argument("--sha", required=True, help="Release commit SHA")
+    parser.add_argument("--workflow", default="final-audit.yml")
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        raise SystemExit("GITHUB_TOKEN is required to verify final-audit evidence")
+    api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+    run = select_successful_run(fetch_runs(api_url, args.repo, args.workflow, token), args.sha)
+    if run is None:
+        raise SystemExit(
+            f"no successful {args.workflow} run was found for release commit {args.sha}"
+        )
+
+    print(f"Final audit OK: {run.get('html_url', '')} ({args.sha})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_versions.py
+++ b/scripts/check_release_versions.py
@@ -13,38 +13,44 @@ import tomllib
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--tag", required=True, help="Release tag, for example v0.2.0")
-    args = parser.parse_args()
-
-    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+def validate_release(root: Path, tag: str) -> tuple[str, str]:
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
     project_version = pyproject["project"]["version"]
 
-    package_init = (ROOT / "coding_tools_mcp" / "__init__.py").read_text(encoding="utf-8")
+    package_init = (root / "coding_tools_mcp" / "__init__.py").read_text(encoding="utf-8")
     match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']', package_init, re.MULTILINE)
     if not match:
         raise SystemExit("coding_tools_mcp.__version__ was not found")
     module_version = match.group(1)
 
     expected_tag = f"v{project_version}"
-    if args.tag != expected_tag:
-        raise SystemExit(f"release tag {args.tag!r} does not match {expected_tag!r}")
+    if tag != expected_tag:
+        raise SystemExit(f"release tag {tag!r} does not match {expected_tag!r}")
     if module_version != project_version:
         raise SystemExit(
             f"pyproject version {project_version!r} does not match module version {module_version!r}"
         )
 
-    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
     if not re.search(rf"^## {re.escape(project_version)} - \d{{4}}-\d{{2}}-\d{{2}}$", changelog, re.MULTILINE):
         raise SystemExit(f"CHANGELOG.md has no dated {project_version} release heading")
     if re.search(r"^## Unreleased\s*$", changelog, re.MULTILINE):
         raise SystemExit("CHANGELOG.md still contains an Unreleased section")
 
-    npm_package = json.loads((ROOT / "npm" / "coding-tools-mcp" / "package.json").read_text(encoding="utf-8"))
+    npm_package = json.loads((root / "npm" / "coding-tools-mcp" / "package.json").read_text(encoding="utf-8"))
     npm_version = npm_package["version"]
     if re.search(r"(?:^|[-.])(alpha|beta|rc|dev|next)(?:[-.]|$)", npm_version, re.IGNORECASE):
         raise SystemExit(f"npm launcher version {npm_version!r} is not stable")
+
+    return project_version, npm_version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", required=True, help="Release tag, for example v0.2.0")
+    args = parser.parse_args()
+
+    project_version, npm_version = validate_release(ROOT, args.tag)
 
     print(
         f"Release metadata OK: Python {project_version} ({args.tag}), "

--- a/scripts/check_release_versions.py
+++ b/scripts/check_release_versions.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Validate release tag, package versions, and release-note coverage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", required=True, help="Release tag, for example v0.2.0")
+    args = parser.parse_args()
+
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    project_version = pyproject["project"]["version"]
+
+    package_init = (ROOT / "coding_tools_mcp" / "__init__.py").read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']', package_init, re.MULTILINE)
+    if not match:
+        raise SystemExit("coding_tools_mcp.__version__ was not found")
+    module_version = match.group(1)
+
+    expected_tag = f"v{project_version}"
+    if args.tag != expected_tag:
+        raise SystemExit(f"release tag {args.tag!r} does not match {expected_tag!r}")
+    if module_version != project_version:
+        raise SystemExit(
+            f"pyproject version {project_version!r} does not match module version {module_version!r}"
+        )
+
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    if not re.search(rf"^## {re.escape(project_version)} - \d{{4}}-\d{{2}}-\d{{2}}$", changelog, re.MULTILINE):
+        raise SystemExit(f"CHANGELOG.md has no dated {project_version} release heading")
+    if re.search(r"^## Unreleased\s*$", changelog, re.MULTILINE):
+        raise SystemExit("CHANGELOG.md still contains an Unreleased section")
+
+    npm_package = json.loads((ROOT / "npm" / "coding-tools-mcp" / "package.json").read_text(encoding="utf-8"))
+    npm_version = npm_package["version"]
+    if re.search(r"(?:^|[-.])(alpha|beta|rc|dev|next)(?:[-.]|$)", npm_version, re.IGNORECASE):
+        raise SystemExit(f"npm launcher version {npm_version!r} is not stable")
+
+    print(
+        f"Release metadata OK: Python {project_version} ({args.tag}), "
+        f"npm launcher {npm_version}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/compliance/test_docs_required.py
+++ b/tests/compliance/test_docs_required.py
@@ -115,6 +115,8 @@ class RequiredDocsTests(unittest.TestCase):
         for needle in (
             "scripts/check_release_versions.py",
             "scripts/check_final_audit.py",
+            'expected_ref="refs/tags/$RELEASE_TAG"',
+            'fetch-depth: 0',
             "Verify wheel contents and installation",
             "pypa/gh-action-pypi-publish",
         ):
@@ -125,6 +127,8 @@ class RequiredDocsTests(unittest.TestCase):
         for needle in (
             "workflow_dispatch",
             "scripts/check_final_audit.py",
+            'expected_ref="refs/tags/$RELEASE_TAG"',
+            'fetch-depth: 0',
             "npm@11.18.0",
             "npm publish",
         ):
@@ -132,7 +136,13 @@ class RequiredDocsTests(unittest.TestCase):
                 self.assertIn(needle, publish_npm)
 
         final_audit = (ROOT / ".github/workflows/final-audit.yml").read_text(encoding="utf-8")
-        for needle in ("git rev-list", "scripts/check_release_versions.py", "Validate referenced runs"):
+        for needle in (
+            "actions/setup-python@v6.2.0",
+            'expected_ref="refs/tags/$RELEASE_TAG"',
+            "git rev-list",
+            "scripts/check_release_versions.py",
+            "Validate referenced runs",
+        ):
             with self.subTest(workflow="final-audit", needle=needle):
                 self.assertIn(needle, final_audit)
 

--- a/tests/compliance/test_docs_required.py
+++ b/tests/compliance/test_docs_required.py
@@ -86,6 +86,7 @@ class RequiredDocsTests(unittest.TestCase):
             "make test",
             "make test-protocol",
             "make test-integration",
+            "make check-npm-launcher",
             "make dogfood-smoke",
             "make benchmark-latency",
             "make benchmark-smoke",
@@ -109,6 +110,31 @@ class RequiredDocsTests(unittest.TestCase):
         for needle in ("docker build", "scripts/mcp_smoke.py"):
             with self.subTest(workflow="docker-smoke", needle=needle):
                 self.assertIn(needle, docker_smoke)
+
+        publish_pypi = (ROOT / ".github/workflows/publish-pypi.yml").read_text(encoding="utf-8")
+        for needle in (
+            "scripts/check_release_versions.py",
+            "scripts/check_final_audit.py",
+            "Verify wheel contents and installation",
+            "pypa/gh-action-pypi-publish",
+        ):
+            with self.subTest(workflow="publish-pypi", needle=needle):
+                self.assertIn(needle, publish_pypi)
+
+        publish_npm = (ROOT / ".github/workflows/publish-npm.yml").read_text(encoding="utf-8")
+        for needle in (
+            "workflow_dispatch",
+            "scripts/check_final_audit.py",
+            "npm@11.18.0",
+            "npm publish",
+        ):
+            with self.subTest(workflow="publish-npm", needle=needle):
+                self.assertIn(needle, publish_npm)
+
+        final_audit = (ROOT / ".github/workflows/final-audit.yml").read_text(encoding="utf-8")
+        for needle in ("git rev-list", "scripts/check_release_versions.py", "Validate referenced runs"):
+            with self.subTest(workflow="final-audit", needle=needle):
+                self.assertIn(needle, final_audit)
 
         smoke_script = (ROOT / "scripts/mcp_smoke.py").read_text(encoding="utf-8")
         for needle in ("server_info", "exec_command"):

--- a/tests/test_release_checks.py
+++ b/tests/test_release_checks.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.check_final_audit import select_successful_run
+from scripts.check_release_versions import validate_release
+
+
+class ReleaseMetadataTests(unittest.TestCase):
+    def _write_release_tree(
+        self,
+        root: Path,
+        *,
+        project_version: str = "0.2.0",
+        module_version: str = "0.2.0",
+        npm_version: str = "0.1.0",
+        changelog: str = "# Changelog\n\n## 0.2.0 - 2026-07-24\n",
+    ) -> None:
+        (root / "coding_tools_mcp").mkdir(parents=True)
+        (root / "npm" / "coding-tools-mcp").mkdir(parents=True)
+        (root / "pyproject.toml").write_text(
+            f'[project]\nversion = "{project_version}"\n', encoding="utf-8"
+        )
+        (root / "coding_tools_mcp" / "__init__.py").write_text(
+            f'__version__ = "{module_version}"\n', encoding="utf-8"
+        )
+        (root / "npm" / "coding-tools-mcp" / "package.json").write_text(
+            json.dumps({"version": npm_version}), encoding="utf-8"
+        )
+        (root / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+
+    def test_release_metadata_accepts_matching_stable_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_release_tree(root)
+            self.assertEqual(validate_release(root, "v0.2.0"), ("0.2.0", "0.1.0"))
+
+    def test_release_metadata_rejects_unreleased_section(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_release_tree(
+                root,
+                changelog="# Changelog\n\n## Unreleased\n\n## 0.2.0 - 2026-07-24\n",
+            )
+            with self.assertRaisesRegex(SystemExit, "Unreleased"):
+                validate_release(root, "v0.2.0")
+
+    def test_release_metadata_rejects_prerelease_npm_version(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_release_tree(root, npm_version="0.1.0-beta.1")
+            with self.assertRaisesRegex(SystemExit, "not stable"):
+                validate_release(root, "v0.2.0")
+
+
+class FinalAuditTests(unittest.TestCase):
+    def test_selects_latest_successful_run_for_release_sha(self) -> None:
+        runs = [
+            {"id": 1, "head_sha": "abc", "status": "completed", "conclusion": "success"},
+            {"id": 3, "head_sha": "abc", "status": "completed", "conclusion": "success"},
+            {"id": 4, "head_sha": "def", "status": "completed", "conclusion": "success"},
+        ]
+        selected = select_successful_run(runs, "abc")
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected["id"], 3)
+
+    def test_rejects_failed_or_incomplete_runs(self) -> None:
+        runs = [
+            {"id": 1, "head_sha": "abc", "status": "completed", "conclusion": "failure"},
+            {"id": 2, "head_sha": "abc", "status": "in_progress", "conclusion": None},
+        ]
+        self.assertIsNone(select_successful_run(runs, "abc"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_checks.py
+++ b/tests/test_release_checks.py
@@ -4,8 +4,9 @@ import json
 from pathlib import Path
 import tempfile
 import unittest
+from urllib.parse import parse_qs, urlparse
 
-from scripts.check_final_audit import select_successful_run
+from scripts.check_final_audit import select_successful_run, workflow_runs_url
 from scripts.check_release_versions import validate_release
 
 
@@ -57,6 +58,20 @@ class ReleaseMetadataTests(unittest.TestCase):
 
 
 class FinalAuditTests(unittest.TestCase):
+    def test_workflow_runs_url_filters_by_release_sha(self) -> None:
+        url = workflow_runs_url(
+            "https://api.github.com", "xyTom/coding-tools-mcp", "final-audit.yml", "abc123"
+        )
+        parsed = urlparse(url)
+        self.assertEqual(
+            parsed.path,
+            "/repos/xyTom/coding-tools-mcp/actions/workflows/final-audit.yml/runs",
+        )
+        self.assertEqual(
+            parse_qs(parsed.query),
+            {"status": ["success"], "head_sha": ["abc123"], "per_page": ["100"]},
+        )
+
     def test_selects_latest_successful_run_for_release_sha(self) -> None:
         runs = [
             {"id": 1, "head_sha": "abc", "status": "completed", "conclusion": "success"},


### PR DESCRIPTION
Applies the reviewed 3-commit release-readiness series preserved on
\`preserve/release-0.2.0-readiness\`:

1. **release: harden 0.2.0 publishing** — new \`publish-npm\` workflow (OIDC + provenance), \`release_tag\` input and tag-pinned checkout for \`publish-pypi\`, wheel-content/entry-point/clean-install verification, \`scripts/check_release_versions.py\` (tag ↔ pyproject ↔ \`__version__\` ↔ CHANGELOG), npm launcher tests, CHANGELOG Unreleased folded into 0.2.0.
2. **fix: require audited registry publishing** — both publish workflows require a successful \`final-audit\` run for the exact release commit (\`scripts/check_final_audit.py\`), npm CLI pinned, docs + unit tests.
3. **fix: bind release provenance to audited tags** — workflow ref / event SHA / checkout SHA / tag SHA must all agree; branch dispatches rejected; \`RELEASE_TAG\` derived from \`pyproject.toml\`; release ordering documented in \`docs/ci-and-tests.md\`.

Review + verification (local): patch series applied cleanly with \`git am --3way\`; \`make check-release\`, \`make check-npm-launcher\` (4/4), lint, mypy, workflow YAML parse, required-docs gate, and the full unittest suite (189/189 in a scrubbed environment) all pass. No runtime code is touched.

Release plan after merge: tag \`v0.2.0\` on the merge commit → dispatch \`compliance\`/\`real-workloads\`/\`swebench-lite\` from the tag → \`final-audit\` with those run IDs → publish the GitHub Release (PyPI) → dispatch \`publish-npm\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)