### PR TITLE
fix: run real-workloads benchmark server in trusted mode

### DIFF
--- a/benchmarks/real_workloads.py
+++ b/benchmarks/real_workloads.py
@@ -171,6 +171,10 @@ def start_server(workspace: Path, port: int, raw_dir: Path, name: str) -> subpro
         "127.0.0.1",
         "--port",
         str(port),
+        # The workloads model local development (`node -e`/`python -c` smoke
+        # commands), which safe mode's inline-script gate rejects by design.
+        "--permission-mode",
+        "trusted",
     ]
     raw_dir.mkdir(parents=True, exist_ok=True)
     stdout = (raw_dir / f"{name}-server.stdout.txt").open("wb")

--- a/reports/benchmark/real-workloads.json
+++ b/reports/benchmark/real-workloads.json
@@ -8,7 +8,7 @@
       "category": "python",
       "checks": [
         {
-          "count": 133,
+          "count": 148,
           "name": "list_files",
           "ok": true
         },
@@ -38,14 +38,14 @@
           "--depth",
           "1",
           "https://github.com/pallets/click.git",
-          "/tmp/codex-real-workloads-jfos6ieh/python-click"
+          "/tmp/codex-real-workloads-sluu9_7_/python-click"
         ],
-        "elapsed_seconds": 0.589,
+        "elapsed_seconds": 0.796,
         "returncode": 0,
-        "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/python-click'...\n",
+        "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/python-click'...\n",
         "stdout": ""
       },
-      "commit": "c9e94136b39b1fad4a47ac0d4478fa372bd07ff8",
+      "commit": "00e592cea702e0b2caa0dee42489fdb1c22cd845",
       "name": "python-click",
       "repo": "https://github.com/pallets/click.git",
       "status": "PASS"
@@ -84,11 +84,11 @@
           "--depth",
           "1",
           "https://github.com/jshttp/mime-types.git",
-          "/tmp/codex-real-workloads-jfos6ieh/node-mime-types"
+          "/tmp/codex-real-workloads-sluu9_7_/node-mime-types"
         ],
-        "elapsed_seconds": 0.457,
+        "elapsed_seconds": 0.45,
         "returncode": 0,
-        "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/node-mime-types'...\n",
+        "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/node-mime-types'...\n",
         "stdout": ""
       },
       "commit": "3a1187ee21388efe46b916d4991589d595bcb26c",
@@ -130,14 +130,14 @@
           "--depth",
           "1",
           "https://github.com/dtolnay/itoa.git",
-          "/tmp/codex-real-workloads-jfos6ieh/rust-itoa"
+          "/tmp/codex-real-workloads-sluu9_7_/rust-itoa"
         ],
-        "elapsed_seconds": 0.471,
+        "elapsed_seconds": 0.682,
         "returncode": 0,
-        "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/rust-itoa'...\n",
+        "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/rust-itoa'...\n",
         "stdout": ""
       },
-      "commit": "af77385d0daf4d0e949e81f2588be2e44f69f086",
+      "commit": "1577ed901354d0d7448ac162328f9dbf5183124c",
       "name": "rust-itoa",
       "repo": "https://github.com/dtolnay/itoa.git",
       "status": "PASS"
@@ -176,11 +176,11 @@
           "--depth",
           "1",
           "https://github.com/google/uuid.git",
-          "/tmp/codex-real-workloads-jfos6ieh/go-uuid"
+          "/tmp/codex-real-workloads-sluu9_7_/go-uuid"
         ],
-        "elapsed_seconds": 0.47,
+        "elapsed_seconds": 0.761,
         "returncode": 0,
-        "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/go-uuid'...\n",
+        "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/go-uuid'...\n",
         "stdout": ""
       },
       "commit": "2d3c2a9cc518326daf99a383f07c4d3c44317e4d",
@@ -192,7 +192,7 @@
       "category": "monorepo",
       "checks": [
         {
-          "count": 221,
+          "count": 268,
           "name": "list_files",
           "ok": true
         },
@@ -215,7 +215,7 @@
           "stdout": "monorepo-workload-ok\n"
         },
         {
-          "bytes": 1048576,
+          "bytes": 147999,
           "name": "large_file",
           "ok": true,
           "path": "mcp-large-workload.txt"
@@ -240,14 +240,14 @@
           "--depth",
           "1",
           "https://github.com/changesets/changesets.git",
-          "/tmp/codex-real-workloads-jfos6ieh/monorepo-changesets"
+          "/tmp/codex-real-workloads-sluu9_7_/monorepo-changesets"
         ],
-        "elapsed_seconds": 0.595,
+        "elapsed_seconds": 0.784,
         "returncode": 0,
-        "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/monorepo-changesets'...\n",
+        "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/monorepo-changesets'...\n",
         "stdout": ""
       },
-      "commit": "372523f4c2ee4ffeb8330d444d47ffb6d0af5126",
+      "commit": "7fd0d9193a7b8bbbb01955adefc68b38d3070616",
       "name": "monorepo-changesets",
       "repo": "https://github.com/changesets/changesets.git",
       "status": "PASS"

--- a/reports/benchmark/real-workloads.md
+++ b/reports/benchmark/real-workloads.md
@@ -8,7 +8,7 @@
 
 - `python-click` (python): **PASS**
   - repo: `https://github.com/pallets/click.git`
-  - commit: `c9e94136b39b1fad4a47ac0d4478fa372bd07ff8`
+  - commit: `00e592cea702e0b2caa0dee42489fdb1c22cd845`
   - list_files: `PASS`
   - read_file: `PASS`
   - search_text: `PASS`
@@ -22,7 +22,7 @@
   - exec_command: `PASS`
 - `rust-itoa` (rust): **PASS**
   - repo: `https://github.com/dtolnay/itoa.git`
-  - commit: `af77385d0daf4d0e949e81f2588be2e44f69f086`
+  - commit: `1577ed901354d0d7448ac162328f9dbf5183124c`
   - list_files: `PASS`
   - read_file: `PASS`
   - search_text: `PASS`
@@ -36,7 +36,7 @@
   - exec_command: `PASS`
 - `monorepo-changesets` (monorepo): **PASS**
   - repo: `https://github.com/changesets/changesets.git`
-  - commit: `372523f4c2ee4ffeb8330d444d47ffb6d0af5126`
+  - commit: `7fd0d9193a7b8bbbb01955adefc68b38d3070616`
   - list_files: `PASS`
   - read_file: `PASS`
   - search_text: `PASS`

--- a/reports/benchmark/real-workloads/raw/go-uuid-exec-allow-roots.txt
+++ b/reports/benchmark/real-workloads/raw/go-uuid-exec-allow-roots.txt
@@ -1,1 +1,1 @@
-/usr/bin:/usr/local/bin
+/usr/bin:/usr/local/bin:/usr/local/cargo:/usr/local/cargo/bin:/usr/local/go:/usr/local/go/bin:/usr/local/rustup

--- a/reports/benchmark/real-workloads/raw/go-uuid-git-clone.json
+++ b/reports/benchmark/real-workloads/raw/go-uuid-git-clone.json
@@ -5,10 +5,10 @@
     "--depth",
     "1",
     "https://github.com/google/uuid.git",
-    "/tmp/codex-real-workloads-jfos6ieh/go-uuid"
+    "/tmp/codex-real-workloads-sluu9_7_/go-uuid"
   ],
-  "elapsed_seconds": 0.47,
+  "elapsed_seconds": 0.761,
   "returncode": 0,
-  "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/go-uuid'...\n",
+  "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/go-uuid'...\n",
   "stdout": ""
 }

--- a/reports/benchmark/real-workloads/raw/go-uuid-git-head.json
+++ b/reports/benchmark/real-workloads/raw/go-uuid-git-head.json
@@ -4,7 +4,7 @@
     "rev-parse",
     "HEAD"
   ],
-  "elapsed_seconds": 0.002,
+  "elapsed_seconds": 0.005,
   "returncode": 0,
   "stderr": "",
   "stdout": "2d3c2a9cc518326daf99a383f07c4d3c44317e4d\n"

--- a/reports/benchmark/real-workloads/raw/go-uuid-server.stderr.txt
+++ b/reports/benchmark/real-workloads/raw/go-uuid-server.stderr.txt
@@ -1,4 +1,4 @@
-codex-tool-runtime-mcp listening on http://127.0.0.1:8873/mcp
+coding-tools-mcp listening on http://127.0.0.1:8873/mcp (no auth configured)
 "POST /mcp HTTP/1.1" 200 -
 "POST /mcp HTTP/1.1" 202 -
 "POST /mcp HTTP/1.1" 200 -

--- a/reports/benchmark/real-workloads/raw/monorepo-changesets-exec-allow-roots.txt
+++ b/reports/benchmark/real-workloads/raw/monorepo-changesets-exec-allow-roots.txt
@@ -1,1 +1,1 @@
-/usr/bin:/usr/local/bin
+/usr/bin:/usr/local/bin:/usr/local/cargo:/usr/local/cargo/bin:/usr/local/go:/usr/local/go/bin:/usr/local/rustup

--- a/reports/benchmark/real-workloads/raw/monorepo-changesets-git-clone.json
+++ b/reports/benchmark/real-workloads/raw/monorepo-changesets-git-clone.json
@@ -5,10 +5,10 @@
     "--depth",
     "1",
     "https://github.com/changesets/changesets.git",
-    "/tmp/codex-real-workloads-jfos6ieh/monorepo-changesets"
+    "/tmp/codex-real-workloads-sluu9_7_/monorepo-changesets"
   ],
-  "elapsed_seconds": 0.595,
+  "elapsed_seconds": 0.784,
   "returncode": 0,
-  "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/monorepo-changesets'...\n",
+  "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/monorepo-changesets'...\n",
   "stdout": ""
 }

--- a/reports/benchmark/real-workloads/raw/monorepo-changesets-git-head.json
+++ b/reports/benchmark/real-workloads/raw/monorepo-changesets-git-head.json
@@ -4,8 +4,8 @@
     "rev-parse",
     "HEAD"
   ],
-  "elapsed_seconds": 0.002,
+  "elapsed_seconds": 0.006,
   "returncode": 0,
   "stderr": "",
-  "stdout": "372523f4c2ee4ffeb8330d444d47ffb6d0af5126\n"
+  "stdout": "7fd0d9193a7b8bbbb01955adefc68b38d3070616\n"
 }

--- a/reports/benchmark/real-workloads/raw/monorepo-changesets-server.stderr.txt
+++ b/reports/benchmark/real-workloads/raw/monorepo-changesets-server.stderr.txt
@@ -1,4 +1,4 @@
-codex-tool-runtime-mcp listening on http://127.0.0.1:8874/mcp
+coding-tools-mcp listening on http://127.0.0.1:8874/mcp (no auth configured)
 "POST /mcp HTTP/1.1" 200 -
 "POST /mcp HTTP/1.1" 202 -
 "POST /mcp HTTP/1.1" 200 -

--- a/reports/benchmark/real-workloads/raw/node-mime-types-exec-allow-roots.txt
+++ b/reports/benchmark/real-workloads/raw/node-mime-types-exec-allow-roots.txt
@@ -1,1 +1,1 @@
-/usr/bin:/usr/local/bin
+/usr/bin:/usr/local/bin:/usr/local/cargo:/usr/local/cargo/bin:/usr/local/go:/usr/local/go/bin:/usr/local/rustup

--- a/reports/benchmark/real-workloads/raw/node-mime-types-git-clone.json
+++ b/reports/benchmark/real-workloads/raw/node-mime-types-git-clone.json
@@ -5,10 +5,10 @@
     "--depth",
     "1",
     "https://github.com/jshttp/mime-types.git",
-    "/tmp/codex-real-workloads-jfos6ieh/node-mime-types"
+    "/tmp/codex-real-workloads-sluu9_7_/node-mime-types"
   ],
-  "elapsed_seconds": 0.457,
+  "elapsed_seconds": 0.45,
   "returncode": 0,
-  "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/node-mime-types'...\n",
+  "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/node-mime-types'...\n",
   "stdout": ""
 }

--- a/reports/benchmark/real-workloads/raw/node-mime-types-git-head.json
+++ b/reports/benchmark/real-workloads/raw/node-mime-types-git-head.json
@@ -4,7 +4,7 @@
     "rev-parse",
     "HEAD"
   ],
-  "elapsed_seconds": 0.002,
+  "elapsed_seconds": 0.004,
   "returncode": 0,
   "stderr": "",
   "stdout": "3a1187ee21388efe46b916d4991589d595bcb26c\n"

--- a/reports/benchmark/real-workloads/raw/node-mime-types-server.stderr.txt
+++ b/reports/benchmark/real-workloads/raw/node-mime-types-server.stderr.txt
@@ -1,4 +1,4 @@
-codex-tool-runtime-mcp listening on http://127.0.0.1:8871/mcp
+coding-tools-mcp listening on http://127.0.0.1:8871/mcp (no auth configured)
 "POST /mcp HTTP/1.1" 200 -
 "POST /mcp HTTP/1.1" 202 -
 "POST /mcp HTTP/1.1" 200 -

--- a/reports/benchmark/real-workloads/raw/python-click-exec-allow-roots.txt
+++ b/reports/benchmark/real-workloads/raw/python-click-exec-allow-roots.txt
@@ -1,1 +1,1 @@
-/usr/bin:/usr/local/bin
+/usr/bin:/usr/local/bin:/usr/local/cargo:/usr/local/cargo/bin:/usr/local/go:/usr/local/go/bin:/usr/local/rustup

--- a/reports/benchmark/real-workloads/raw/python-click-git-clone.json
+++ b/reports/benchmark/real-workloads/raw/python-click-git-clone.json
@@ -5,10 +5,10 @@
     "--depth",
     "1",
     "https://github.com/pallets/click.git",
-    "/tmp/codex-real-workloads-jfos6ieh/python-click"
+    "/tmp/codex-real-workloads-sluu9_7_/python-click"
   ],
-  "elapsed_seconds": 0.589,
+  "elapsed_seconds": 0.796,
   "returncode": 0,
-  "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/python-click'...\n",
+  "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/python-click'...\n",
   "stdout": ""
 }

--- a/reports/benchmark/real-workloads/raw/python-click-git-head.json
+++ b/reports/benchmark/real-workloads/raw/python-click-git-head.json
@@ -4,8 +4,8 @@
     "rev-parse",
     "HEAD"
   ],
-  "elapsed_seconds": 0.002,
+  "elapsed_seconds": 0.007,
   "returncode": 0,
   "stderr": "",
-  "stdout": "c9e94136b39b1fad4a47ac0d4478fa372bd07ff8\n"
+  "stdout": "00e592cea702e0b2caa0dee42489fdb1c22cd845\n"
 }

--- a/reports/benchmark/real-workloads/raw/python-click-server.stderr.txt
+++ b/reports/benchmark/real-workloads/raw/python-click-server.stderr.txt
@@ -1,4 +1,4 @@
-codex-tool-runtime-mcp listening on http://127.0.0.1:8870/mcp
+coding-tools-mcp listening on http://127.0.0.1:8870/mcp (no auth configured)
 "POST /mcp HTTP/1.1" 200 -
 "POST /mcp HTTP/1.1" 202 -
 "POST /mcp HTTP/1.1" 200 -

--- a/reports/benchmark/real-workloads/raw/rust-itoa-exec-allow-roots.txt
+++ b/reports/benchmark/real-workloads/raw/rust-itoa-exec-allow-roots.txt
@@ -1,1 +1,1 @@
-/usr/bin:/usr/local/bin
+/usr/bin:/usr/local/bin:/usr/local/cargo:/usr/local/cargo/bin:/usr/local/go:/usr/local/go/bin:/usr/local/rustup

--- a/reports/benchmark/real-workloads/raw/rust-itoa-git-clone.json
+++ b/reports/benchmark/real-workloads/raw/rust-itoa-git-clone.json
@@ -5,10 +5,10 @@
     "--depth",
     "1",
     "https://github.com/dtolnay/itoa.git",
-    "/tmp/codex-real-workloads-jfos6ieh/rust-itoa"
+    "/tmp/codex-real-workloads-sluu9_7_/rust-itoa"
   ],
-  "elapsed_seconds": 0.471,
+  "elapsed_seconds": 0.682,
   "returncode": 0,
-  "stderr": "Cloning into '/tmp/codex-real-workloads-jfos6ieh/rust-itoa'...\n",
+  "stderr": "Cloning into '/tmp/codex-real-workloads-sluu9_7_/rust-itoa'...\n",
   "stdout": ""
 }

--- a/reports/benchmark/real-workloads/raw/rust-itoa-git-head.json
+++ b/reports/benchmark/real-workloads/raw/rust-itoa-git-head.json
@@ -4,8 +4,8 @@
     "rev-parse",
     "HEAD"
   ],
-  "elapsed_seconds": 0.001,
+  "elapsed_seconds": 0.019,
   "returncode": 0,
   "stderr": "",
-  "stdout": "af77385d0daf4d0e949e81f2588be2e44f69f086\n"
+  "stdout": "1577ed901354d0d7448ac162328f9dbf5183124c\n"
 }

--- a/reports/benchmark/real-workloads/raw/rust-itoa-server.stderr.txt
+++ b/reports/benchmark/real-workloads/raw/rust-itoa-server.stderr.txt
@@ -1,4 +1,4 @@
-codex-tool-runtime-mcp listening on http://127.0.0.1:8872/mcp
+coding-tools-mcp listening on http://127.0.0.1:8872/mcp (no auth configured)
 "POST /mcp HTTP/1.1" 200 -
 "POST /mcp HTTP/1.1" 202 -
 "POST /mcp HTTP/1.1" 200 -


### PR DESCRIPTION
The \`v0.2.0\` evidence run of \`real-workloads\` failed 4/5 workloads with
\`INLINE_SCRIPT_PERMISSION_REQUIRED\`: the workload smoke commands are
\`node -e\`/\`python -c\` inline scripts, and the benchmark starts its server
without \`--permission-mode\`, landing on \`safe\` — whose inline-script gate
rejects them by design (the gate's own \`suggested_server_flag\` is
\`--permission-mode trusted\`). The only passing workload, python-click, uses
non-inline \`python -m compileall\`, which confirms the mechanism.

Fix: start the benchmark server in \`trusted\` mode — the documented mode for
exactly the local-development pattern these workloads model. No product code
changes; the permission gate itself keeps its own coverage in
\`make test-security\`.

Verified locally: 5/5 workloads PASS, conclusion PASS, exit 0 (report
refreshed in this PR).

After merge, \`v0.2.0\` will be re-tagged on the new merge commit and the three
evidence workflows re-dispatched from it, per the audit chain's same-commit
requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)