### PR TITLE
fix: publish npm tarball by local path, not github shorthand

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -104,4 +104,6 @@ jobs:
         run: npm install --global npm@11.18.0
 
       - name: Publish launcher with provenance
-        run: npm publish dist/*.tgz --access public --provenance
+        # The ./ prefix is load-bearing: without it npm parses the argument as
+        # a GitHub owner/repo shorthand instead of a local tarball path.
+        run: npm publish ./dist/*.tgz --access public --provenance


### PR DESCRIPTION
The v0.2.0 \`publish-npm\` run failed at the final step with exit 128:
npm parsed \`dist/coding-tools-mcp-0.1.0.tgz\` (single slash, no \`./\`
prefix) as a GitHub \`owner/repo\` shorthand and ran
\`git ls-remote ssh://git@github.com/dist/coding-tools-mcp-0.1.0.tgz.git\`
instead of publishing the local tarball. Everything before it — launcher
tests, version validation, ref/SHA binding, final-audit check, pack — was
green; only the tarball argument form was wrong.

One-line fix: \`npm publish ./dist/*.tgz\` — the \`./\` prefix forces
local-path interpretation. The docs-required needle (\`npm publish\`) still
matches.

Note: the tag's copy of the workflow keeps the old form, so the automated
npm publish becomes available from the next audited tag onward; see the
conversation for the interim options for launcher 0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)