### PR TITLE
release: 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.1 - 2026-07-26
 
 ### Changed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,6 @@ message: "If you use this project, please cite it as below."
 title: "Coding Tools MCP"
 authors:
   - name: "Coding Tools MCP Contributors"
-version: "0.2.0"
+version: "0.2.1"
 license: "Apache-2.0"
 repository-code: "https://github.com/xyTom/coding-tools-mcp"

--- a/coding_tools_mcp/__init__.py
+++ b/coding_tools_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Coding Tools MCP server package."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coding-tools-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Workspace-confined coding tools exposed as an MCP server."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Version bump for the first release through the new one-action pipeline:

- \`pyproject.toml\` / \`coding_tools_mcp.__version__\` / \`CITATION.cff\` → 0.2.1
- CHANGELOG \`Unreleased\` (one-action release pipeline + anonymous telemetry)
  folded into \`## 0.2.1 - 2026-07-26\`
- npm launcher stays at 0.1.0 — not yet on the registry, so \`release.yml\`
  will publish it with provenance and flip \`latest\` off the beta

Verified: \`check_release_versions --tag v0.2.1\`, lint, telemetry +
release-check + docs-required tests.

After merge, pushing \`v0.2.1\` triggers the full pipeline: evidence →
build/verify → PyPI → npm → GitHub Release. No inputs, no dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)