### PR TITLE
docs: rewrite README around value, quickstart, and distinctive uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,311 +1,164 @@
 # Coding Tools MCP
 
-Coding Tools MCP is a model-neutral coding-agent runtime MCP server. It exposes local coding primitives to any MCP client:
+> Give any AI chat or agent a safe pair of hands on your codebase.
 
-```text
-inspect repo -> search/read files -> apply structured patches -> run tests/commands
--> interact with stdin sessions -> inspect git status/diff
-```
+[![PyPI](https://img.shields.io/pypi/v/coding-tools-mcp)](https://pypi.org/project/coding-tools-mcp/)
+[![npm](https://img.shields.io/npm/v/coding-tools-mcp)](https://www.npmjs.com/package/coding-tools-mcp)
+[![Python](https://img.shields.io/pypi/pyversions/coding-tools-mcp)](https://pypi.org/project/coding-tools-mcp/)
+[![compliance](https://github.com/xyTom/coding-tools-mcp/actions/workflows/compliance.yml/badge.svg)](https://github.com/xyTom/coding-tools-mcp/actions/workflows/compliance.yml)
+[![release](https://github.com/xyTom/coding-tools-mcp/actions/workflows/release.yml/badge.svg)](https://github.com/xyTom/coding-tools-mcp/actions/workflows/release.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-## Demo Video
+Coding Tools MCP is a **model-neutral coding runtime** served over the
+[Model Context Protocol](https://modelcontextprotocol.io): file reading and
+search, structured multi-file patches, command execution, interactive
+sessions, and git — one server that any MCP client can drive. Claude Desktop,
+Claude Code, Cursor, Cline, or an agent you build yourself all get the same
+20 battle-tested tools, confined to one workspace, gated by permission modes.
 
 [![Watch the demo](https://img.youtube.com/vi/N9lQaXt1eqQ/maxresdefault.jpg)](https://youtu.be/N9lQaXt1eqQ?si=LyEwvzzQF6QjUxR0)
 
-It is not a prompt wrapper. It does not expose external agent accounts, memory, cloud tasks, web search, image generation, model routing, plugin marketplace, or subagent orchestration as MCP tools.
+## Why people use it
 
-## Documentation Map
-
-- [Quickstart](docs/quickstart.md)
-- [MCP client configuration](docs/mcp-client-config.md)
-- [Embedding in your app or agent](docs/embedding.md)
-- [Remote MCP](docs/remote-mcp.md)
-- [Cloudflare sandbox control worker](cloudflare/sandbox-control/README.md)
-- [npm launcher](npm/coding-tools-mcp/README.md)
-- [Tools and schemas](docs/tools-and-schemas.md)
-- [Permission modes](docs/permission-modes.md)
-- [Exec command recipes](docs/exec-command-recipes.md)
-- [Docker sandbox](docs/docker.md)
-- [Security policy](SECURITY.md)
-- [Security boundary](docs/security-boundary.md)
-- [CI and test commands](docs/ci-and-tests.md)
-- [Dogfood](docs/dogfood.md)
-- [SWE-bench evaluation](docs/swe-bench.md)
-- [Known limitations](docs/limitations.md)
-- [Troubleshooting](docs/troubleshooting.md)
-- [Exec troubleshooting](docs/troubleshooting-exec.md)
-- [Competitive analysis](docs/competitive-analysis.md)
-- Normative runtime contract: [docs/runtime-contract-v0.2.md](docs/runtime-contract-v0.2.md)
+- **It turns a chat app into a coding agent.** Claude Desktop — or any MCP
+  chat client — gets real repo access with the subscription you already have.
+  No extra product required.
+- **Safety is the product, not an afterthought.** One workspace root per
+  server. Absolute paths, `..` traversal, and symlink escapes are rejected.
+  Permission modes gate network access, shell expansion, inline scripts, and
+  destructive commands. On Linux, [Landlock](docs/security-boundary.md) adds
+  kernel-level filesystem confinement.
+- **It is model- and vendor-neutral.** A fixed, truthfully annotated catalog —
+  no profile switching, no annotation games. Swap models or clients freely;
+  the runtime and its behavior stay put.
+- **It is engineered for context windows.** Results are summarized, paginated,
+  and capped by design; serialized tool-result bytes dropped 37%
+  release-over-release on the deterministic dogfood workload with unchanged
+  task completion.
 
 ## Quickstart
 
-Install the published command from PyPI:
+Run it with whichever toolchain you already have (the server is Python ≥ 3.11
+from PyPI; the npm package is a thin launcher that starts it via `uv` or
+`pipx`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/xyTom/coding-tools-mcp/main/scripts/install.sh | bash
+uvx coding-tools-mcp --stdio --workspace /path/to/repo   # Python toolchain
+npx coding-tools-mcp --stdio --workspace /path/to/repo   # Node toolchain
 ```
 
-Install and start local Streamable HTTP against a workspace:
+Wire it into Claude Desktop, Claude Code, Cursor, or Cline — the JSON is the
+same everywhere (swap `uvx` for `npx` if you prefer Node):
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/xyTom/coding-tools-mcp/main/scripts/install.sh \
-  | bash -s -- --start --workspace /path/to/repo
+```json
+{
+  "mcpServers": {
+    "coding-tools": {
+      "command": "uvx",
+      "args": ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
+    }
+  }
+}
 ```
 
-Install and expose an authenticated bearer-token tunnel:
+Then ask your client: *"run the test suite and fix the first failure."*
+
+Prefer HTTP? Drop `--stdio` and the server speaks Streamable HTTP on
+`http://127.0.0.1:8765/mcp` (MCP `2025-11-25`, with `2025-06-18`
+compatibility). A one-line installer, per-client walkthroughs, and
+troubleshooting live in [docs/quickstart.md](docs/quickstart.md) and
+[docs/mcp-client-config.md](docs/mcp-client-config.md).
+
+## Seven things to try
+
+**1. Make Claude Desktop your coding agent.** The config above is all it
+takes — the chat window you already pay for can now read, patch, test, and
+commit-review a real repository.
+
+**2. Code on your own machine from anywhere.**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/xyTom/coding-tools-mcp/main/scripts/install.sh \
-  | bash -s -- --tunnel cloudflared --auto-install-tunnel --workspace /path/to/repo
+CODING_TOOLS_MCP_AUTH_MODE=bearer ./scripts/tunnel.sh cloudflared /path/to/repo
 ```
 
-Or, from this checkout:
+Loopback bind + authenticated HTTPS tunnel (`cloudflared`, `ngrok`, or
+Microsoft Dev Tunnel). Point claude.ai on your phone at
+`https://<tunnel-host>/mcp` and drive your home workstation from anywhere.
+Bearer tokens and OAuth 2.1 + PKCE (with RFC 7591 dynamic registration) are
+built in. → [docs/remote-mcp.md](docs/remote-mcp.md)
+
+**3. Let an agent loose on untrusted code — inside a disposable sandbox.**
 
 ```bash
-scripts/install.sh
+docker build -t coding-tools-mcp-sandbox:local .
+docker run --rm --init -it -p 8765:8765 -v "$PWD:/workspace" coding-tools-mcp-sandbox:local
 ```
 
-Run the published package without a persistent install:
+A containerized server with toolchains and caches preconfigured, safe to point
+at a sketchy PR and destroy afterwards. → [docs/docker.md](docs/docker.md)
+
+**4. Spin up a cloud sandbox with one MCP call.** The bundled
+[Cloudflare Worker control plane](cloudflare/sandbox-control/README.md) exposes
+`start_coding_tools_sandbox` as an MCP tool: one call dispatches a GitHub
+Actions runner that boots the Docker sandbox and publishes it behind an
+authenticated Cloudflare Tunnel. Ephemeral compute, no server of your own.
+
+**5. Drive it from a GUI.**
 
 ```bash
-uvx coding-tools-mcp --workspace .
-```
-
-Use stdio for MCP clients:
-
-```bash
-uvx coding-tools-mcp --stdio --workspace /path/to/repo
-```
-
-If your toolchain is Node-based, launch the same server through npm:
-
-```bash
-npx coding-tools-mcp --stdio --workspace /path/to/repo
-```
-
-The npm package is a launcher only. The server itself stays the Python package
-on PyPI, which the launcher starts through `uvx` or `pipx run`, so `uv` or
-`pipx` must be on `PATH`. The launcher runs the latest PyPI release; pin a
-server version with `CODING_TOOLS_MCP_VERSION`:
-
-```bash
-CODING_TOOLS_MCP_VERSION=0.2.0 npx coding-tools-mcp --stdio --workspace /path/to/repo
-```
-
-The launcher's own npm version is independent of the server version it starts.
-
-If you are working from this checkout instead of a published package:
-
-```bash
-make start
-```
-
-Pass a different workspace, host, port, or extra server flags with Make variables:
-
-```bash
-make start MCP_WORKSPACE=/path/to/repo MCP_PORT=8000 MCP_ARGS="--permission-mode trusted"
-```
-
-If dependencies are missing, install the runtime in editable mode:
-
-```bash
-python -m pip install -e ".[dev]"
-```
-
-Run the desktop client MVP:
-
-```bash
-python -m pip install -e ".[desktop]"
+python -m pip install "coding-tools-mcp[desktop]"
 coding-tools-mcp-desktop
 ```
 
-The desktop client follows the system language on first launch and can switch between English and Simplified Chinese at runtime.
+Per-workspace profiles, server and tunnel start/stop, credential setup with
+clipboard helpers, live health checks. English and 简体中文.
 
-HTTP endpoint:
+**6. Keep an interactive session alive.** `exec_command` starts a REPL or
+debugger under a real PTY; `write_stdin` feeds it across turns; `read_output`
+pages long output; `kill_session` cleans up. Long-running processes are
+first-class, with deadline watchdogs and bounded buffers.
 
-```text
-http://127.0.0.1:8765/mcp
-```
+**7. Give your own agent production-grade hands.** Building an agent loop with
+the Anthropic SDK or anything else? Don't hand-roll file and exec tools —
+speak MCP to this server and inherit the whole safety boundary. →
+[docs/embedding.md](docs/embedding.md)
 
-Install the optional image extra when you want `view_image` auto-resize support:
+## The tool catalog
 
-```bash
-python -m pip install -e ".[image]"
-```
+One stable, truthfully annotated set — permission modes change command
+*policy*, never which tools the model sees. `apply_patch` is the sole
+file-mutation primitive: staged, baseline-checked, atomic across files, with
+rollback.
 
-Stdio:
+| Group | Tools |
+| --- | --- |
+| Files & search | `read_file` · `list_dir` · `list_files` · `search_text` · `apply_patch` · `view_image` |
+| Execution | `exec_command` · `write_stdin` · `read_output` · `kill_session` · `request_permissions` |
+| Git | `git_status` · `git_diff` · `git_log` · `git_show` · `git_blame` |
+| Runtime | `server_info` · `check_exec_environment` · `get_default_cwd` · `set_default_cwd` |
 
-```bash
-coding-tools-mcp --stdio --workspace /path/to/repo
-```
-
-Set `CODING_TOOLS_MCP_TRACE=1` to emit redacted JSON tool-call trace events to stderr for local debugging. Logs stay off stdout so stdio JSON-RPC remains clean.
-
-By default, `exec_command` passes a core shell environment only. For local toolchains that depend on inherited environment variables, such as MSVC developer prompts, start with:
-
-```bash
-CODING_TOOLS_MCP_SHELL_ENV_INHERIT=all coding-tools-mcp --workspace /path/to/repo
-```
-
-`inherit=all` still filters secret-looking and loader/startup variables unless dangerous mode is also enabled. For local development with dependency downloads, shell expansion, and inline interpreter snippets, use:
-
-```bash
-coding-tools-mcp --permission-mode trusted --workspace /path/to/repo
-```
-
-`--allow-network` remains available as a compatibility flag when you only want to open network-looking commands. If your MCP client does not support permission elicitation and you explicitly want to disable `exec_command` permission gates inside an isolated container or VM, start with:
-
-```bash
-coding-tools-mcp --permission-mode dangerous --workspace /path/to/repo
-```
-
-This disables `exec_command` permission gates such as network-looking commands, destructive command checks, shell expansion, inline scripts, and sensitive env checks. Workspace path boundaries for direct file tools still apply. `--dangerously-skip-all-permissions` remains as a compatibility alias.
-
-## MCP Client Examples
-
-Generic stdio client:
-
-```toml
-[mcp_servers.coding_tools]
-command = "uvx"
-args = ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
-```
-
-Claude Code:
-
-```json
-{
-  "mcpServers": {
-    "coding-tools": {
-      "command": "uvx",
-      "args": ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
-    }
-  }
-}
-```
-
-Cursor:
-
-```json
-{
-  "mcpServers": {
-    "coding-tools": {
-      "command": "uvx",
-      "args": ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
-    }
-  }
-}
-```
-
-Clients that prefer a Node entry point can swap `uvx` for `npx` in any of the
-examples above, keeping the same arguments:
-
-```json
-{
-  "mcpServers": {
-    "coding-tools": {
-      "command": "npx",
-      "args": ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
-    }
-  }
-}
-```
-
-Generic Streamable HTTP clients should use MCP protocol version `2025-11-25`
-and point at `http://127.0.0.1:8765/mcp`. Version `2025-06-18` remains
-supported for existing clients.
-
-## Remote MCP
-
-For remote MCP clients and local development over an HTTPS tunnel, keep the
-server bound to loopback and require bearer or OAuth authentication. The fixed
-tool set contains command execution and workspace mutation, so an anonymous
-public tunnel is unsafe:
-
-```bash
-CODING_TOOLS_MCP_AUTH_MODE=bearer \
-./scripts/tunnel.sh cloudflared /path/to/repo
-```
-
-Configure the remote MCP client with the HTTPS tunnel URL:
-
-```text
-URL: https://<tunnel-host>/mcp
-```
-
-The tunnel scripts support `cloudflared`, `ngrok`, and Microsoft Dev Tunnel. If the selected tunnel CLI is missing, the script asks before installing it:
-
-```bash
-scripts/tunnel.sh cloudflared /path/to/repo
-scripts/tunnel.sh ngrok /path/to/repo
-scripts/tunnel.sh devtunnel /path/to/repo
-```
-
-For clients that support custom headers, use bearer-token auth with
-`Authorization: Bearer <token>`. OAuth-aware clients can use OAuth 2.1
-Authorization Code + PKCE by setting `CODING_TOOLS_MCP_AUTH_MODE=oauth`. The
-server publishes RFC 7591 dynamic client registration, binds exact redirect
-URIs, and can infer its issuer from a one-shot tunnel request. Set
-`CODING_TOOLS_MCP_SERVER_URL` only to pin a stable issuer. Clients that support
-neither bearer headers nor OAuth need an external authenticated proxy.
-
-See [docs/remote-mcp.md](docs/remote-mcp.md) for the exact modes and security notes.
-
-## Fixed Tool Set
-
-The server exposes one stable catalog with truthful annotations. It does not
-offer tool profiles, dynamically hide process tools, or provide `edit_file`.
-`apply_patch` is the only direct file-mutation primitive. Permission modes
-change command policy, not which tools the model sees.
-
-## Tools
-
-P0 tools exposed by default:
-
-- `server_info`
-- `check_exec_environment`
-- `get_default_cwd`
-- `set_default_cwd`
-- `read_file`
-- `list_dir`
-- `list_files`
-- `search_text`
-- `apply_patch`
-- `exec_command`
-- `write_stdin`
-- `kill_session`
-- `read_output`
-- `git_status`
-- `git_diff`
-- `git_log`
-- `git_show`
-- `git_blame`
-- `request_permissions`
-
-Additional image tool exposed by default:
-
-- `view_image`
-
-For input/output schemas and result envelopes, see
-[docs/tools-and-schemas.md](docs/tools-and-schemas.md) and
+Root `AGENTS.md`/`CLAUDE.md` files load into the initialize context
+automatically. Tool `content` is concise agent-facing text;
+`structuredContent` carries the complete machine result. Schemas and result
+envelopes: [docs/tools-and-schemas.md](docs/tools-and-schemas.md) ·
 [docs/runtime-contract-v0.2.md](docs/runtime-contract-v0.2.md).
-
-Root `AGENTS.md`/`CLAUDE.md` instructions are loaded into the MCP initialize
-context automatically; nested instruction files are indexed without eagerly
-injecting their contents. No `open_workspace` tool call is required.
-
-Tool `content` is concise agent-facing text, while `structuredContent` is the
-complete stable machine result. Commands wait up to 10 seconds by default. Only
-commands still running return a `write_stdin` next action; only truncated output
-returns a `read_output` next action. Image base64 is emitted once in one MCP
-image block.
 
 ## Safety Boundary
 
-The runtime binds one workspace root per server process. Paths are workspace-relative by default. Absolute paths, `..` traversal, and symlink escapes are rejected. Recursive listing/search excludes `.git`, `.reference`, `node_modules`, `target`, `dist`, build outputs, virtualenvs, and common caches by default.
+| Mode | Meant for | What it allows |
+| --- | --- | --- |
+| `safe` (default) | day-to-day agent work | file tools and vetted commands; network-looking commands, shell expansion, inline scripts, and destructive commands all require explicit permission |
+| `trusted` | local development | opens network, shell expansion, and inline scripts; keeps secret filtering and destructive-command checks |
+| `dangerous` | isolated containers/VMs only | disables `exec_command` permission gates; workspace path boundaries still apply |
 
-`exec_command` runs under policy controls with workspace-bound cwd, configurable shell environment inheritance, timeout, output caps, sensitive-value and loader/startup environment rejection, destructive command checks, network-looking command checks, shell-expansion permission gates, indirect absolute-path checks, cancellation/kill cleanup, session deadline watchdogs, and bounded session buffers. On Linux hosts with Landlock support it also applies filesystem confinement; on Windows, macOS, or Linux hosts without Landlock, command results include a warning and external sandboxing is required before running untrusted commands. This is still not a complete OS/container sandbox; see [SECURITY.md](SECURITY.md).
-
-`--permission-mode safe` is the default. `--permission-mode trusted` opens local-development gates while keeping secret filtering and destructive-command checks. `--permission-mode dangerous` disables `exec_command` permission gates for operators who accept that risk inside an isolated runner. Do not use dangerous mode for untrusted workspaces or untrusted MCP clients.
+Recursive listing and search exclude `.git`, `node_modules`, build outputs,
+virtualenvs, and caches. Commands run with workspace-bound cwd, scrubbed
+environment, timeouts, and output caps. Linux hosts with Landlock get
+kernel-enforced filesystem confinement; other platforms get an explicit
+warning — this is still not a complete OS sandbox, so use the Docker image or
+a VM for genuinely untrusted work. Details:
+[SECURITY.md](SECURITY.md) · [docs/security-boundary.md](docs/security-boundary.md) ·
+[docs/permission-modes.md](docs/permission-modes.md)
 
 ## Telemetry
 
@@ -317,29 +170,37 @@ in CI. `CODING_TOOLS_MCP_TELEMETRY=debug` prints every event to stderr instead
 of sending. The full event list and guarantees are in
 [docs/telemetry.md](docs/telemetry.md).
 
-## Compliance
+## Evidence, Dogfood and SWE-bench
+
+Every release ships through a tag-triggered pipeline in which the compliance
+suite, real-workload benchmark, and SWE-bench harness run from the same commit
+that publishes to PyPI and npm — both via trusted publishing, npm with
+provenance. Dogfood efficiency metrics are reproducible (`make dogfood-smoke`)
+and checked in under `reports/`. This repository does not claim a
+model-generated SWE-bench leaderboard result — see
+[docs/swe-bench.md](docs/swe-bench.md) for exactly what is and is not
+measured. More: [COMPLIANCE.md](COMPLIANCE.md) · [BENCHMARK.md](BENCHMARK.md) ·
+[docs/dogfood.md](docs/dogfood.md)
+
+## Documentation
+
+| | |
+| --- | --- |
+| Getting started | [Quickstart](docs/quickstart.md) · [Client configuration](docs/mcp-client-config.md) · [Troubleshooting](docs/troubleshooting.md) |
+| Remote & sandboxed | [Remote MCP](docs/remote-mcp.md) · [Docker sandbox](docs/docker.md) · [Cloud sandbox worker](cloudflare/sandbox-control/README.md) |
+| Tools & contract | [Tools and schemas](docs/tools-and-schemas.md) · [Runtime contract](docs/runtime-contract-v0.2.md) · [Permission modes](docs/permission-modes.md) |
+| Execution | [Exec recipes](docs/exec-command-recipes.md) · [Exec troubleshooting](docs/troubleshooting-exec.md) |
+| Integration | [Embedding](docs/embedding.md) · [npm launcher](npm/coding-tools-mcp/README.md) |
+| Security & quality | [Security policy](SECURITY.md) · [Security boundary](docs/security-boundary.md) · [CI and tests](docs/ci-and-tests.md) · [Limitations](docs/limitations.md) · [Competitive analysis](docs/competitive-analysis.md) |
+
+## Development
 
 ```bash
-make compliance
+python -m pip install -e ".[dev]"
+make ci        # lint, typecheck, tests, protocol/integration suites, gates
 ```
 
-Compliance and CI commands are documented in [docs/ci-and-tests.md](docs/ci-and-tests.md). The checked-in report files are generated artifacts; inspect their `suite` field before treating them as full compliance evidence.
-
-## Dogfood And Benchmark
-
-Dogfood and SWE-bench notes live in [docs/dogfood.md](docs/dogfood.md), [docs/swe-bench.md](docs/swe-bench.md), and [BENCHMARK.md](BENCHMARK.md). This repository does not claim a model-generated SWE-bench leaderboard result.
-
-## Development Commands
-
-```bash
-make lint
-make typecheck
-make test
-make compliance
-make ci
-```
-
-See [docs/ci-and-tests.md](docs/ci-and-tests.md) for the full test matrix.
+The full gate matrix is in [docs/ci-and-tests.md](docs/ci-and-tests.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coding Tools MCP
 
+**English** | [简体中文](README.zh-CN.md)
+
 > Give any AI chat or agent a safe pair of hands on your codebase.
 
 [![PyPI](https://img.shields.io/pypi/v/coding-tools-mcp)](https://pypi.org/project/coding-tools-mcp/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,202 @@
+# Coding Tools MCP
+
+[English](README.md) | **简体中文**
+
+> 让任何 AI 聊天应用或 agent，都能安全地上手你的代码仓库。
+
+[![PyPI](https://img.shields.io/pypi/v/coding-tools-mcp)](https://pypi.org/project/coding-tools-mcp/)
+[![npm](https://img.shields.io/npm/v/coding-tools-mcp)](https://www.npmjs.com/package/coding-tools-mcp)
+[![Python](https://img.shields.io/pypi/pyversions/coding-tools-mcp)](https://pypi.org/project/coding-tools-mcp/)
+[![compliance](https://github.com/xyTom/coding-tools-mcp/actions/workflows/compliance.yml/badge.svg)](https://github.com/xyTom/coding-tools-mcp/actions/workflows/compliance.yml)
+[![release](https://github.com/xyTom/coding-tools-mcp/actions/workflows/release.yml/badge.svg)](https://github.com/xyTom/coding-tools-mcp/actions/workflows/release.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
+Coding Tools MCP 是一个**模型中立的编程运行时**，通过
+[Model Context Protocol](https://modelcontextprotocol.io) 对外提供服务：
+文件读取与搜索、结构化多文件补丁、命令执行、交互式会话、git 操作——
+一个服务器，任何 MCP 客户端都能驱动。Claude Desktop、Claude Code、Cursor、
+Cline，或你自己写的 agent，拿到的都是同一套久经考验的 20 个工具：
+限定在单一工作区内，由权限模式层层把关。
+
+[![观看演示](https://img.youtube.com/vi/N9lQaXt1eqQ/maxresdefault.jpg)](https://youtu.be/N9lQaXt1eqQ?si=LyEwvzzQF6QjUxR0)
+
+## 为什么用它
+
+- **让聊天应用变成编程 agent。**Claude Desktop——或任何 MCP 聊天客户端——
+  用你已有的订阅直接获得真实的仓库访问能力，无需额外产品。
+- **安全是产品本身，不是附加项。**每个服务器进程绑定一个工作区根目录；
+  绝对路径、`..` 穿越、符号链接逃逸一律拒绝；权限模式对网络访问、shell
+  展开、内联脚本和破坏性命令逐项把关；Linux 上还有
+  [Landlock](docs/security-boundary.md) 提供内核级文件系统隔离。
+- **模型与厂商中立。**固定且如实标注的工具目录——没有 profile 切换，
+  没有注解把戏。随意更换模型或客户端，运行时行为保持不变。
+- **为上下文窗口精打细算。**工具结果按设计做摘要、分页与封顶；在确定性
+  dogfood 工作负载上，序列化结果字节数相比上一版本下降 37%，任务完成率不变。
+
+## 快速开始
+
+用你手头已有的工具链启动（服务器本体是 PyPI 上的 Python ≥ 3.11 包；
+npm 包是一个轻量启动器，会通过 `uv` 或 `pipx` 拉起服务器）：
+
+```bash
+uvx coding-tools-mcp --stdio --workspace /path/to/repo   # Python 工具链
+npx coding-tools-mcp --stdio --workspace /path/to/repo   # Node 工具链
+```
+
+接入 Claude Desktop、Claude Code、Cursor 或 Cline——各家的 JSON 配置完全相同
+（偏好 Node 的话把 `uvx` 换成 `npx` 即可）：
+
+```json
+{
+  "mcpServers": {
+    "coding-tools": {
+      "command": "uvx",
+      "args": ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
+    }
+  }
+}
+```
+
+然后对你的客户端说一句：*"跑一下测试，把第一个失败修了。"*
+
+想用 HTTP？去掉 `--stdio`，服务器就在
+`http://127.0.0.1:8765/mcp` 上讲 Streamable HTTP（MCP `2025-11-25`，
+兼容 `2025-06-18`）。一行安装脚本、各客户端的完整接入指南和排障见
+[docs/quickstart.md](docs/quickstart.md) 与
+[docs/mcp-client-config.md](docs/mcp-client-config.md)。
+
+## 七个值得一试的玩法
+
+**1. 让 Claude Desktop 成为你的编程 agent。**上面那份配置就是全部——你已经在
+付费的聊天窗口，现在能读代码、打补丁、跑测试、看 diff。
+
+**2. 随时随地连回自己的电脑写代码。**
+
+```bash
+CODING_TOOLS_MCP_AUTH_MODE=bearer ./scripts/tunnel.sh cloudflared /path/to/repo
+```
+
+回环地址绑定 + 带认证的 HTTPS 隧道（`cloudflared`、`ngrok` 或 Microsoft Dev
+Tunnel）。手机上打开 claude.ai，指向 `https://<tunnel-host>/mcp`，就能驱动家里的
+工作站。内置 Bearer token 与 OAuth 2.1 + PKCE（含 RFC 7591 动态注册）。
+→ [docs/remote-mcp.md](docs/remote-mcp.md)
+
+**3. 在一次性 Docker 沙箱里放心跑可疑代码。**
+
+```bash
+docker build -t coding-tools-mcp-sandbox:local .
+docker run --rm --init -it -p 8765:8765 -v "$PWD:/workspace" coding-tools-mcp-sandbox:local
+```
+
+容器化的服务器，工具链和缓存都预配好——放心把 agent 指向一个来路不明的
+PR，用完即毁。→ [docs/docker.md](docs/docker.md)
+
+**4. 一个 MCP 调用，起一台云沙箱。**内置的
+[Cloudflare Worker 控制面](cloudflare/sandbox-control/README.md) 把
+`start_coding_tools_sandbox` 暴露为 MCP 工具：一次调用即派发 GitHub Actions
+运行器，启动 Docker 沙箱并发布到带认证的 Cloudflare Tunnel 之后。
+临时算力，无需自备服务器。
+
+**5. 用图形界面操作。**
+
+```bash
+python -m pip install "coding-tools-mcp[desktop]"
+coding-tools-mcp-desktop
+```
+
+按工作区管理配置、一键启停服务器与隧道、凭证设置带剪贴板助手、实时健康
+检查。支持英文与简体中文。
+
+**6. 保持一个活着的交互式会话。**`exec_command` 在真实 PTY 下启动 REPL 或
+调试器；`write_stdin` 跨轮次喂输入；`read_output` 分页读取长输出；
+`kill_session` 干净收尾。长时进程是一等公民，配有会话看门狗与有界缓冲。
+
+**7. 给自研 agent 装上生产级的"手"。**用 Anthropic SDK 或任何框架搭 agent
+循环？别再手写文件和执行工具——对着这个服务器讲 MCP，整个安全边界直接
+继承。→ [docs/embedding.md](docs/embedding.md)
+
+## 工具目录
+
+一套稳定且如实标注的目录——权限模式改变的是命令*策略*，而不是模型看到哪些
+工具。`apply_patch` 是唯一的文件修改原语：分阶段、基线校验、跨文件原子提交、
+支持回滚。
+
+| 分组 | 工具 |
+| --- | --- |
+| 文件与搜索 | `read_file` · `list_dir` · `list_files` · `search_text` · `apply_patch` · `view_image` |
+| 执行 | `exec_command` · `write_stdin` · `read_output` · `kill_session` · `request_permissions` |
+| Git | `git_status` · `git_diff` · `git_log` · `git_show` · `git_blame` |
+| 运行时 | `server_info` · `check_exec_environment` · `get_default_cwd` · `set_default_cwd` |
+
+仓库根部的 `AGENTS.md`/`CLAUDE.md` 会自动载入 initialize 上下文。工具的
+`content` 是给 agent 看的精炼文本，`structuredContent` 则是完整稳定的机器
+结果。Schema 与结果封装：
+[docs/tools-and-schemas.md](docs/tools-and-schemas.md) ·
+[docs/runtime-contract-v0.2.md](docs/runtime-contract-v0.2.md)
+
+## 安全边界
+
+| 模式 | 适用场景 | 放行范围 |
+| --- | --- | --- |
+| `safe`（默认） | 日常 agent 工作 | 文件工具与常规命令；疑似联网命令、shell 展开、内联脚本、破坏性命令均需显式授权 |
+| `trusted` | 本地开发 | 放开网络、shell 展开与内联脚本；保留敏感值过滤与破坏性命令检查 |
+| `dangerous` | 仅限隔离容器/虚拟机 | 关闭 `exec_command` 权限门；工作区路径边界依然生效 |
+
+递归列举与搜索默认排除 `.git`、`node_modules`、构建产物、虚拟环境和常见
+缓存。命令在工作区限定的 cwd 下运行，环境经过清洗，带超时与输出上限。
+支持 Landlock 的 Linux 主机获得内核级文件系统隔离；其他平台会收到明确
+警告——这仍不是完整的操作系统级沙箱，真正不可信的工作请用 Docker 镜像或
+虚拟机。详见：
+[SECURITY.md](SECURITY.md) · [docs/security-boundary.md](docs/security-boundary.md) ·
+[docs/permission-modes.md](docs/permission-modes.md)
+
+## 遥测
+
+服务器会发送匿名使用遥测（每工具的成功率/延迟计数与版本/平台维度——
+绝不包含路径、参数、命令或文件内容），用于确定修复优先级。设置
+`CODING_TOOLS_MCP_TELEMETRY=off` 或 `DO_NOT_TRACK=1` 可关闭；CI 环境自动
+关闭。`CODING_TOOLS_MCP_TELEMETRY=debug` 会把每个事件打印到 stderr 而不
+发送。完整事件清单与承诺见 [docs/telemetry.md](docs/telemetry.md)。
+
+## 证据、Dogfood 与 SWE-bench
+
+每个版本都经由 tag 触发的流水线发布：合规套件、真实工作负载基准和
+SWE-bench 评测与 registry 发布运行在同一个 commit 上——PyPI 与 npm 均走
+trusted publishing，npm 带 provenance。Dogfood 效率指标可复现
+（`make dogfood-smoke`），报告存于 `reports/`。本仓库不宣称任何模型生成的
+SWE-bench 榜单成绩——[docs/swe-bench.md](docs/swe-bench.md) 写明了测了什么、
+没测什么。更多：[COMPLIANCE.md](COMPLIANCE.md) ·
+[BENCHMARK.md](BENCHMARK.md) · [docs/dogfood.md](docs/dogfood.md)
+
+## 文档
+
+| | |
+| --- | --- |
+| 上手 | [快速开始](docs/quickstart.md) · [客户端配置](docs/mcp-client-config.md) · [排障](docs/troubleshooting.md) |
+| 远程与沙箱 | [Remote MCP](docs/remote-mcp.md) · [Docker 沙箱](docs/docker.md) · [云沙箱 Worker](cloudflare/sandbox-control/README.md) |
+| 工具与契约 | [工具与 Schema](docs/tools-and-schemas.md) · [运行时契约](docs/runtime-contract-v0.2.md) · [权限模式](docs/permission-modes.md) |
+| 命令执行 | [Exec 配方](docs/exec-command-recipes.md) · [Exec 排障](docs/troubleshooting-exec.md) |
+| 集成 | [嵌入指南](docs/embedding.md) · [npm 启动器](npm/coding-tools-mcp/README.md) |
+| 安全与质量 | [安全策略](SECURITY.md) · [安全边界](docs/security-boundary.md) · [CI 与测试](docs/ci-and-tests.md) · [已知限制](docs/limitations.md) · [竞品分析](docs/competitive-analysis.md) |
+
+## 开发
+
+```bash
+python -m pip install -e ".[dev]"
+make ci        # lint、类型检查、测试、协议/集成套件与各项门禁
+```
+
+完整门禁矩阵见 [docs/ci-and-tests.md](docs/ci-and-tests.md)。
+
+## 许可证
+
+本项目基于 [Apache License 2.0](LICENSE) 发布。
+
+如果你使用了本项目的代码、文档、实质性实现细节或衍生成果，请保留版权
+声明、许可证声明与 [NOTICE](NOTICE) 文件，并清晰注明出处。
+
+Project: Coding Tools MCP  
+Author: Coding Tools MCP Contributors  
+Source: https://github.com/xyTom/coding-tools-mcp
+
+引用元数据见 [CITATION.cff](CITATION.cff)。


### PR DESCRIPTION
The old README was accurate but organized like a reference manual — the value
proposition, the 60-second start, and the genuinely distinctive workflows were
buried. This rewrite reorganizes it for a first-time visitor:

1. **Hero**: one-line pitch, six badges, demo video, three-sentence summary.
2. **Why people use it**: four bullets — chat-app-as-coding-agent, safety as
   the product (Landlock, permission modes), vendor neutrality, and the
   measured −37% token-bytes result.
3. **Quickstart**: uvx/npx one-liners plus a single JSON block that works in
   Claude Desktop, Claude Code, Cursor, and Cline.
4. **Seven things to try**: the distinctive workflows, each with a runnable
   snippet — including the tunnel-to-your-workstation remote setup, the
   disposable Docker sandbox, and the one-MCP-call cloud sandbox worker.
5. Tool catalog and safety modes compressed into tables; doc map folded into
   a two-column index; telemetry, evidence, and license sections preserved.

Verified: required-docs needles (Quickstart / Safety Boundary / Dogfood /
SWE-bench) still pass and all 40 local links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)