### PR TITLE
docs: add client configuration for Claude Desktop, Gemini CLI, Grok, ChatGPT, VS Code, and Windsurf

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Coding Tools MCP is a **model-neutral coding runtime** served over the
 [Model Context Protocol](https://modelcontextprotocol.io): file reading and
 search, structured multi-file patches, command execution, interactive
 sessions, and git — one server that any MCP client can drive. Claude Desktop,
-Claude Code, Cursor, Cline, or an agent you build yourself all get the same
-18 battle-tested tools, confined to one workspace, gated by permission modes.
+Claude Code, Codex, Cursor, Cline, VS Code, Windsurf, Gemini CLI, or an agent
+you build yourself all get the same 18 battle-tested tools, confined to one
+workspace, gated by permission modes.
 
 [![Watch the demo](https://img.youtube.com/vi/N9lQaXt1eqQ/maxresdefault.jpg)](https://youtu.be/N9lQaXt1eqQ?si=LyEwvzzQF6QjUxR0)
 
@@ -49,8 +50,9 @@ uvx coding-tools-mcp --stdio --workspace /path/to/repo   # Python toolchain
 npx coding-tools-mcp --stdio --workspace /path/to/repo   # Node toolchain
 ```
 
-Wire it into Claude Desktop, Claude Code, Cursor, or Cline — the JSON is the
-same everywhere (swap `uvx` for `npx` if you prefer Node):
+Wire it into Claude Desktop, Claude Code, Codex, Cursor, VS Code, Windsurf,
+Gemini CLI, or Cline — the JSON is the same everywhere (swap `uvx` for `npx`
+if you prefer Node):
 
 ```json
 {
@@ -89,6 +91,7 @@ CODING_TOOLS_MCP_AUTH_MODE=bearer ./scripts/tunnel.sh cloudflared /path/to/repo
 Loopback bind + authenticated HTTPS tunnel (`cloudflared`, `ngrok`, or
 Microsoft Dev Tunnel). Point claude.ai on your phone at
 `https://<tunnel-host>/mcp` and drive your home workstation from anywhere.
+ChatGPT and Grok connect through their connector settings the same way.
 Bearer tokens and OAuth 2.1 + PKCE (with RFC 7591 dynamic registration) are
 built in. → [docs/remote-mcp.md](docs/remote-mcp.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,9 +14,9 @@
 Coding Tools MCP 是一个**模型中立的编程运行时**，通过
 [Model Context Protocol](https://modelcontextprotocol.io) 对外提供服务：
 文件读取与搜索、结构化多文件补丁、命令执行、交互式命令、git 操作——
-一个服务器，任何 MCP 客户端都能驱动。Claude Desktop、Claude Code、Cursor、
-Cline，或你自己写的 agent，拿到的都是同一套久经考验的 18 个工具：
-限定在单一工作区内，由权限模式层层把关。
+一个服务器，任何 MCP 客户端都能驱动。Claude Desktop、Claude Code、Codex、
+Cursor、Cline、VS Code、Windsurf、Gemini CLI，或你自己写的 agent，拿到的
+都是同一套久经考验的 18 个工具：限定在单一工作区内，由权限模式层层把关。
 
 [![观看演示](https://img.youtube.com/vi/N9lQaXt1eqQ/maxresdefault.jpg)](https://youtu.be/N9lQaXt1eqQ?si=LyEwvzzQF6QjUxR0)
 
@@ -43,8 +43,9 @@ uvx coding-tools-mcp --stdio --workspace /path/to/repo   # Python 工具链
 npx coding-tools-mcp --stdio --workspace /path/to/repo   # Node 工具链
 ```
 
-接入 Claude Desktop、Claude Code、Cursor 或 Cline——各家的 JSON 配置完全相同
-（偏好 Node 的话把 `uvx` 换成 `npx` 即可）：
+接入 Claude Desktop、Claude Code、Codex、Cursor、VS Code、Windsurf、
+Gemini CLI 或 Cline——各家的 JSON 配置完全相同（偏好 Node 的话把 `uvx`
+换成 `npx` 即可）：
 
 ```json
 {
@@ -80,7 +81,8 @@ CODING_TOOLS_MCP_AUTH_MODE=bearer ./scripts/tunnel.sh cloudflared /path/to/repo
 
 回环地址绑定 + 带认证的 HTTPS 隧道（`cloudflared`、`ngrok` 或 Microsoft Dev
 Tunnel）。手机上打开 claude.ai，指向 `https://<tunnel-host>/mcp`，就能驱动家里的
-工作站。内置 Bearer token 与 OAuth 2.1 + PKCE（含 RFC 7591 动态注册）。
+工作站。ChatGPT 与 Grok 通过各自的连接器设置同样接入。内置 Bearer token 与
+OAuth 2.1 + PKCE（含 RFC 7591 动态注册）。
 → [docs/remote-mcp.md](docs/remote-mcp.md)
 
 **3. 在一次性 Docker 沙箱里放心跑可疑代码。**

--- a/docs/mcp-client-config.md
+++ b/docs/mcp-client-config.md
@@ -5,6 +5,22 @@ no configuration and no handshake: it discovers the server with
 `server/discover` and states its version in every request. A handshake client
 uses `2025-11-25`, and `2025-06-18` remains supported for existing clients.
 
+## Claude Desktop
+
+Edit `claude_desktop_config.json` — `~/Library/Application Support/Claude/` on
+macOS, `%APPDATA%\Claude\` on Windows — and restart Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "coding-tools": {
+      "command": "uvx",
+      "args": ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
+    }
+  }
+}
+```
+
 ## Codex
 
 ```toml
@@ -26,6 +42,12 @@ args = ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
 }
 ```
 
+Or from the command line:
+
+```bash
+claude mcp add coding-tools -- uvx coding-tools-mcp --stdio --workspace /path/to/repo
+```
+
 ## Cursor
 
 ```json
@@ -38,6 +60,72 @@ args = ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
   }
 }
 ```
+
+## VS Code
+
+GitHub Copilot reads `.vscode/mcp.json` in the workspace:
+
+```json
+{
+  "servers": {
+    "coding-tools": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
+    }
+  }
+}
+```
+
+For the local HTTP server instead, use `"type": "http"` with `"url"` and
+`"headers"` keys.
+
+## Windsurf
+
+Edit `~/.codeium/windsurf/mcp_config.json` and restart Windsurf:
+
+```json
+{
+  "mcpServers": {
+    "coding-tools": {
+      "command": "uvx",
+      "args": ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
+    }
+  }
+}
+```
+
+## Gemini CLI
+
+One command, project scope by default:
+
+```bash
+gemini mcp add coding-tools -- uvx coding-tools-mcp --stdio --workspace /path/to/repo
+```
+
+Or edit `~/.gemini/settings.json` (user scope) or `.gemini/settings.json`
+(project scope):
+
+```json
+{
+  "mcpServers": {
+    "coding-tools": {
+      "command": "uvx",
+      "args": ["coding-tools-mcp", "--stdio", "--workspace", "/path/to/repo"]
+    }
+  }
+}
+```
+
+For the local HTTP server, transport `http` replaces the command entirely:
+
+```bash
+gemini mcp add --transport http coding-tools http://127.0.0.1:8765/mcp
+```
+
+Authenticated endpoints take `--header "Authorization: Bearer <token>"`. Keep
+the server name free of underscores: Gemini CLI derives tool names from it and
+splits on the first one.
 
 ## Continue, Cursor, Cline, And Generic HTTP Clients
 
@@ -71,3 +159,48 @@ Static bearer-token auth is available for clients that support custom
 publishes protected-resource and authorization-server discovery plus RFC 7591
 dynamic registration and a PKCE authorization flow. Clients that support
 neither require an external authenticated proxy. See [Remote MCP](remote-mcp.md).
+
+## ChatGPT
+
+ChatGPT is a cloud client: it cannot launch a local process, so it needs the
+authenticated HTTPS tunnel from [Remote MCP](#remote-mcp), and its custom
+connectors offer OAuth or no authentication — there is no static bearer
+header to enter.
+
+```bash
+CODING_TOOLS_MCP_AUTH_MODE=oauth scripts/tunnel.sh cloudflared /path/to/repo
+```
+
+In ChatGPT, enable developer mode (Settings → Connectors → Advanced
+settings), then create a custom connector pointing at
+`https://<tunnel-host>/mcp`. If ChatGPT discovers the OAuth endpoints itself,
+the authorization page asks for the password the script printed. If the
+connector form asks for details instead, fill them in:
+
+- Authorization URL: `https://<tunnel-host>/oauth/authorize`
+- Token URL: `https://<tunnel-host>/oauth/token`
+- Client ID and secret: from a pre-registered client — start the tunnel with
+  `CODING_TOOLS_MCP_OAUTH_CLIENT_ID`,
+  `CODING_TOOLS_MCP_OAUTH_CLIENT_SECRET`, and
+  `CODING_TOOLS_MCP_OAUTH_REDIRECT_URIS` set to the redirect URI ChatGPT
+  shows.
+
+## Grok
+
+grok.com is also cloud-only. Start the same OAuth tunnel, then add a custom
+connector at grok.com/connectors (Settings → Connectors) with
+`https://<tunnel-host>/mcp`; Grok completes the OAuth flow in a popup.
+
+The xAI API takes the static bearer tunnel instead — a request's remote MCP
+tool entry pins the server and the header:
+
+```json
+{
+  "server_url": "https://<tunnel-host>/mcp",
+  "server_label": "coding_tools",
+  "authorization": "<CODING_TOOLS_MCP_AUTH_TOKEN>"
+}
+```
+
+Only Streamable HTTP and SSE transports are supported on Grok's side, which
+is what the tunnel already speaks.


### PR DESCRIPTION
## Summary

`docs/mcp-client-config.md` covered only Codex, Claude Code, and Cursor. This PR extends it to the remaining common MCP hosts, with each host's configuration format verified against its current vendor documentation. Server behavior is unchanged — every path already works over stdio or Streamable HTTP; this closes a documentation gap only.

### Local stdio clients

- **Claude Desktop** — `claude_desktop_config.json` location per platform
- **Claude Code** — adds the `claude mcp add` one-liner alongside the existing JSON
- **VS Code (GitHub Copilot)** — `.vscode/mcp.json` with the `servers` / `type: "stdio"` shape, noting the `type: "http"` variant for the local HTTP server
- **Windsurf** — `~/.codeium/windsurf/mcp_config.json`
- **Gemini CLI** — `gemini mcp add` for stdio and `--transport http`, `~/.gemini/settings.json` vs `.gemini/settings.json` scopes, and the underscore-in-server-name caveat (tool names are derived from it)

### Cloud connector clients (tunnel + auth)

- **ChatGPT (developer mode)** — cloud-only, needs the HTTPS tunnel; connectors offer OAuth or no authentication, with no static bearer header to enter, so the OAuth tunnel is the documented path. Includes the manual-form fallback (authorize/token URLs, pre-registered client via `CODING_TOOLS_MCP_OAUTH_CLIENT_*`)
- **Grok** — grok.com custom connector completes OAuth in a popup; the xAI API's remote MCP tools take `server_url` + `authorization` (static bearer tunnel) instead

### README updates (en + zh-CN)

- Client lists in the intro and quickstart extended to match
- The remote-access bullet now mentions ChatGPT/Grok connector setup

## Test plan

- [x] `python -m tests.compliance.runner --suite docs-required` — 4/4 OK
- [x] Local HTTP smoke: `initialize` (2025-11-25) + `tools/list` → 18 tools on `http://127.0.0.1:8765/mcp`
- [x] Local stdio smoke: initialize → `notifications/initialized` → `tools/call` `read_file` — `isError: false`, `structuredContent` present
- [ ] Manual verification in each GUI client (maintainers/community welcome): Claude Desktop JSON, `claude mcp add`, `gemini mcp add` (stdio + http), VS Code `.vscode/mcp.json`
- [ ] Live tunnel + OAuth against a ChatGPT developer-mode connector and a grok.com custom connector
