### PR TITLE
feat: expose CLI version

### DIFF
--- a/coding_tools_mcp/server.py
+++ b/coding_tools_mcp/server.py
@@ -5699,6 +5699,11 @@ def run_stdio(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Serve workspace-confined coding tools over MCP.")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
     parser.add_argument("--workspace", help="workspace root; defaults to CODING_TOOLS_MCP_WORKSPACE or cwd")
     parser.add_argument(
         "--host",

--- a/tests/compliance/test_runtime_helpers.py
+++ b/tests/compliance/test_runtime_helpers.py
@@ -353,6 +353,18 @@ class RuntimeHelperTests(unittest.TestCase):
         self.assertIn("--permission-mode", result.stdout)
         self.assertIn("--allow-network", result.stdout)
 
+    def test_package_module_entrypoint_exposes_version(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "coding_tools_mcp", "--version"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), f"__main__.py {server_module.__version__}")
+
     def test_workspace_init_tolerates_missing_home_lookup(self) -> None:
         with TemporaryDirectory() as tmp:
             with patch.object(server_module.Path, "home", side_effect=RuntimeError("home unavailable")):


### PR DESCRIPTION
## Summary

- add a standard `--version` option to the server CLI
- cover the module entrypoint with a regression test

This gives installers and runtime supervisors a stable way to verify the installed package version without inspecting environment-specific metadata paths.

## Verification

- `make lint`
- `make typecheck`
- `make test` (275 tests passed, 5 skipped)